### PR TITLE
feat(canvas): implement architecture diagramming canvas with drag-and…

### DIFF
--- a/app/canvas/layout.tsx
+++ b/app/canvas/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Supabricx Canvas",
+  description: "AI-powered architecture design tool",
+};
+
+export default function CanvasRootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-background font-display text-foreground">
+      {children}
+    </div>
+  );
+}

--- a/app/canvas/page.tsx
+++ b/app/canvas/page.tsx
@@ -1,0 +1,5 @@
+import CanvasLayout from "@/components/canvas/CanvasLayout";
+
+export default function Page() {
+  return <CanvasLayout />;
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -4,9 +4,11 @@ import React, { useState } from "react";
 import { ArrowUpRight, GithubLogo } from "@phosphor-icons/react";
 import Button from "./Button";
 import ChatInterface from "./ChatInterface";
+import { useRouter } from "next/navigation";
 
 const Navbar = () => {
   const [isChatOpen, setIsChatOpen] = useState(false);
+  const router = useRouter();
 
   const handleGithubClick = () => {
     setIsChatOpen(true);
@@ -36,10 +38,11 @@ const Navbar = () => {
           />
           <div className="hidden md:block">
             <Button
-              title="Join the Beta"
+              title="Get Started"
               Icon={ArrowUpRight}
               width="220px"
               height="60px"
+              onClick={() => router.push('/canvas')}
             />
           </div>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,37 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap');
 @import "tailwindcss";
 
+@theme {
+  --color-background: #0a0a0a;
+  --color-foreground: #ffffff;
+  --color-card-bg: #171717;
+  --color-border-dark: #262626;
+  --color-muted: #a3a3a3;
+  --color-orange-400: #fb923c;
+  --color-orange-500: #f97316;
+  
+  --font-display: var(--font-dynapuff), sans-serif;
+  --font-mono: var(--font-dm-mono), monospace;
+
+  --image-gradient-orange: linear-gradient(to right, #fb923c, #f97316);
+}
+
+/* Custom Utilities */
+.gradient-orange {
+  background-image: linear-gradient(to right, var(--color-orange-400), var(--color-orange-500));
+}
+
+.gradient-orange-text {
+  background-image: linear-gradient(to right, var(--color-orange-400), var(--color-orange-500));
+  background-clip: text;
+  color: transparent;
+}
+
+.bg-dot-pattern {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
 * {
   font-family: "Source Code Pro", monospace;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, DynaPuff, DM_Mono } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -10,6 +10,18 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const dynaPuff = DynaPuff({
+  variable: "--font-dynapuff",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+}); 
+
+const dmMono = DM_Mono({
+  variable: "--font-dm-mono",
+  subsets: ["latin"],
+  weight: ["300", "400", "500"],
 });
 
 export const metadata: Metadata = {
@@ -28,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${dynaPuff.variable} ${dmMono.variable} antialiased`}
       >
         {children}
       </body>

--- a/canvas.txt
+++ b/canvas.txt
@@ -1,0 +1,395 @@
+Build a production-ready canvas layout for Supabricx - an AI-powered architecture design tool. Create a three-panel interface with left sidebar (component library), center canvas (node editor), and right sidebar (AI chat).
+
+## 🎨 DESIGN THEME (UPDATED)
+
+### Base Colors
+- Site Background: `#0a0a0a` (deep charcoal black)
+- Primary Accent: Tailwind gradient `from-orange-400 to-orange-500`
+- Text Primary: `#ffffff` / `#f5f5f5`
+- Text Secondary: `#a3a3a3` (muted gray)
+- Borders: `#262626` (subtle dark border)
+- Card Background: `#171717` (slightly lighter than base)
+- Hover Background: `#262626`
+
+### Tailwind Config Extension
+```javascript
+// tailwind.config.js
+theme: {
+  extend: {
+    colors: {
+      background: '#0a0a0a',
+      foreground: '#ffffff',
+      'card-bg': '#171717',
+      'border-dark': '#262626',
+      'muted': '#a3a3a3',
+      orange: {
+        400: '#fb923c',
+        500: '#f97316',
+      }
+    },
+    backgroundImage: {
+      'gradient-orange': 'linear-gradient(to right, #fb923c, #f97316)',
+    },
+    fontFamily: {
+      display: ['var(--font-dynapuff)', 'sans-serif'],
+      mono: ['var(--font-dm-mono)', 'monospace'],
+    }
+  }
+}
+
+Background Pattern
+Subtle DOT pattern (NOT grid lines)
+Dot specs: 1px diameter, #ffffff color, 4% opacity
+Spacing: 32px horizontal and vertical
+Implementation: CSS radial-gradient in globals.css
+Should be barely visible – adds texture without distraction
+Typography
+css
+12345678910111213141516171819
+Icon Library
+Use Phosphor Icons (@phosphor-icons/react)
+Replace all Lucide references with Phosphor equivalents
+Icon size: 20px for UI, 24px for nodes, 16px for inline
+Weight: regular for UI, bold for active states
+📦 TECH STACK
+Framework: Next.js 14 (App Router) with TypeScript
+Styling: Tailwind CSS v4.2+
+Canvas Library: React Flow v11+
+Animations: Framer Motion
+Icons: @phosphor-icons/react
+State Management: Zustand
+Fonts: Dynapuff (display), DM Mono (code)
+🏗️ FILE STRUCTURE
+1234567891011121314151617181920212223242526272829303132333435363738394041424344454647484950
+/app
+  /canvas
+    /page.tsx (main canvas page)
+  /layout.tsx (font + metadata setup)
+  /globals.css (dot pattern + base styles)
+/components
+  /canvas
+    CanvasLayout.tsx (3-panel flex container)
+    TopToolbar.tsx
+    LeftSidebar.tsx
+
+
+link the page to get started in Navbar.tsx <Button
+              title="Get Started"
+              Icon={ArrowUpRight}
+              width="220px"
+              height="60px"
+            />
+📐 COMPONENT SPECIFICATIONS
+1. CanvasLayout.tsx (Main Container)
+typescript
+12345678
+// Three-panel horizontal flex layout
+// h-screen, w-screen, overflow-hidden, bg-background (#0a0a0a)
+// Left Sidebar: fixed 280px (collapsible to 64px), border-r border-border-dark
+// Center Canvas: flex-1, relative, overflow-hidden
+// Right Sidebar: fixed 380px (collapsible to 0px), border-l border-border-dark
+// Resize handles: 3px wide, hover:bg-orange-500/30, cursor-col-resize
+// Collapsed state: persisted to localStorage
+// Transition: width 200ms ease-in-out
+2. TopToolbar.tsx
+typescript
+12345678910111213141516
+// Fixed top, h-14 (56px), border-b border-border-dark
+// bg-card-bg/80 backdrop-blur-md for subtle depth
+// Left section:
+//   - Supabricx logo: Dynapuff font, orange gradient text (bg-clip-text)
+//   - Diagram title: editable Input, font-mono, placeholder "Untitled Diagram"
+//   - Save status: small dot indicator (green=saved, orange=saving, gray=unsaved)
+// Center section:
+//   - Undo/Redo: Phosphor ArrowUturnLeft/Right icons, hover:bg-border-dark
+//   - Zoom: − 100% + buttons, orange gradient bo
+3. LeftSidebar.tsx (Component Library)
+typescript
+1234567891011121314151617181920212223
+// Width: 280px expanded, 64px collapsed
+// bg-card-bg, border-r border-border-dark, overflow-y-auto
+// Header:
+//   - "Components" label: font-display, text-foreground
+//   - Collapse toggle: Phosphor CaretLeft/CaretRight, hover:text-orange-400
+//   - Search input: bg-background, border border-border-dark, placeholder text-muted
+// Category Sections (collapsible with Phosphor CaretDown):
+//   • Compute: Server, Cloud, CPU, Lightning icons
+//   • Data: Database, Table, HardDrive icons  
+//   • M
+4. CanvasArea.tsx (React Flow Implementation)
+typescript
+1234567891011121314151617181920212223242526272829
+// React Flow Provider with custom theme
+// Background: dot pattern from globals.css
+// Default sample nodes on first load:
+//   - API Gateway (top-center, GatewayNode)
+//   - 2x Microservice nodes (below, connected)
+//   - PostgreSQL node (connected to service, solid edge)
+//   - Redis node (connected with dashed "async" edge)
+// React Flow Theme Overrides:
+//   - Background: transparent (dot pattern shows through)
+//   - Edge color: #a3a3a3, selected: orange-400
+
+5. RightSidebar.tsx (AI Chat Panel)
+typescript
+12345678910111213141516171819202122232425262728
+// Width: 380px expanded, 0px collapsed
+// bg-card-bg, border-l border-border-dark, flex-col
+// Header:
+//   - "AI Assistant": font-display, text-foreground
+//   - Clear history: Phosphor Trash icon, hover:text-red-400
+//   - Settings: Phosphor Gear icon, hover:text-orange-400
+//   - Collapse toggle: Phosphor CaretRight
+// Chat History (scrollable, flex-1, p-4):
+//   - User messages:
+//     * Right-aligned, bg-gradient-orange text-white
+
+6. Node Components
+BaseNode.tsx
+typescript
+123456789101112131415
+// Wrapper for all node types
+// Width: 200px default, resizable via handles
+// Container: bg-card-bg, border border-border-dark, rounded-lg, shadow-lg
+// Header bar: h-8, bg-gradient-orange, rounded-t-lg
+//   - Node icon: Phosphor icon, white, 16px
+//   - Node label: font-display, text-white, text-xs, editable on double-click
+//   - Actions menu: Phosphor DotsThreeVertical, dropdown on click
+// Body: p-3, bg-background
+//   - Properties: font-mono, text-xs, text-muted, key-value pairs
+//   - St
+ServiceNode.tsx (Microservice)
+typescript
+12345678
+// Extends BaseNode structure
+// Icon: Phosphor Server or Cube
+// Additional properties (font-mono, text-xs):
+//   - Language: badge with orange border (Python/Node/Go)
+//   - Port: ":8080" format
+//   - Health: status dot + "OK"/"Degraded"
+//   - Instances: "x3" badge
+// Visual: subtle code-bracket decoration in corner (Phosphor Code, 10% opacity)
+DatabaseNode.tsx
+typescript
+12345678
+// Extends BaseNode structure  
+// Icon: Phosphor Database
+// Additional properties:
+//   - Type: "PostgreSQL" / "MongoDB" badge
+//   - Connection: masked string "postgres://***"
+//   - Storage: "50GB" indicator
+//   - Replicas: "1 primary + 2 read" text
+// Visual: subtle cylinder pattern overlay (5% opacity)
+GatewayNode.tsx
+typescript
+1234567
+// Extends BaseNode structure
+// Icon: Phosphor Shield or Gate
+// Additional properties:
+//   - Type: "API Gateway" / "Load Balancer"
+//   - Rules: "12 routes" count
+//   - Rate limit: "1000 req/min" badge
+// Visual: subtle shield pattern or arrow flow animation (CSS)
+7. Chat Components
+ChatMessage.tsx
+typescript
+12345678910111213
+// Props: { role: 'user' | 'assistant', content: string, timestamp: Date, suggestions?: Suggestion[] }
+// User message:
+//   - bg-gradient-orange, text-white, rounded-lg rounded-tr-none
+//   - font-display, text-sm, leading-relaxed
+//   - Right-aligned, max-w-[85%], ml-auto
+//   - Code blocks: font-mono, bg-black/30, rounded, p-2
+// AI message:
+//   - bg-background, border border-border-dark, rounded-lg rounded-tl-none
+//   - font-display for prose, font-mono for code
+//   - Left-aligned, max-w-
+ChatInput.tsx
+typescript
+1234567891011121314
+// Textarea: 
+//   - bg-background, border border-border-dark, rounded-lg
+//   - font-mono, text-sm, text-foreground, placeholder:text-muted
+//   - focus:ring-1 ring-orange-400, focus:border-orange-400
+//   - auto-resize via useTextareaResize hook
+// Character count: optional, text-xs text-muted, bottom-right
+// Attachment indicator: Phosphor CheckCircle (green) when file/URL attached
+// Send button: 
+//   - Phosphor PaperPlaneRight, bg-gradient-orange, rounded-lg
+//   - hover:opacity-90, disabl
+SuggestionCard.tsx
+typescript
+123456789101112
+// Container: border border-border-dark, rounded-lg, p-4, mt-2, bg-background
+// Title: font-display, text-foreground, font-medium, mb-2
+// Severity badge: 
+//   - High: bg-red-500/20 text-red-400 border border-red-500/30
+//   - Medium: bg-orange-500/20 text-orange-400 border border-orange-500/30  
+//   - Low: bg-green-500/20 text-green-400 border border-green-500/30
+// Diagram preview: mini canvas thumbnail (120x80px), border border-border-dark
+// Code diff preview: collapsible section, font-mo
+🎬 ANIMATIONS & INTERACTIONS (Framer Motion)
+Sidebar Transitions
+typescript
+123456
+Chat Message Entry
+typescript
+123456789
+Node Interactions
+typescript
+12345
+Gradient Button Hover
+typescript
+12
+Interactive States Summary
+All clickable elements: hover:bg-border-dark or hover:border-orange-400
+Active/dragging nodes: orange ring + elevated shadow
+Loading states: skeleton cards with orange gradient shimmer
+Toast notifications: slide-in from top-right, orange accent border
+Confirmation dialogs: backdrop blur, orange primary button
+🧠 STATE MANAGEMENT (Zustand)
+useCanvasStore.ts
+typescript
+1234567891011121314151617181920212223242526272829303132333435363738394041424344454647
+interface CanvasState {
+  // Graph data
+  nodes: Node[];
+  edges: Edge[];
+  
+  // Selection
+  selectedNodeIds: string[];
+  selectedEdgeIds: string[];
+  
+  // Viewport
+
+useChatStore.ts
+typescript
+1234567891011121314151617181920
+interface ChatState {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  attachedFile: File | null;
+  attachedUrl: string | null;
+  
+  addMessage: (message: ChatMessage) => void;
+  clearHistory: () => void;
+  sendMessage: (content: string) => Promise<void>;
+  setAttachment: (file: File | null, url: string | null) => void;
+
+🎨 STYLING DETAILS
+globals.css
+css
+1234567891011121314151617181920212223242526272829303132333435363738394041424344454647484950515253545556575859606162
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: #0a0a0a;
+    --foreground: #ffffff;
+    --card-bg: #171717;
+    --border-dark: #262626;
+
+Gradient Utility Class
+css
+1234567
+/* Add to globals.css or use Tailwind arbitrary values */
+.gradient-orange {
+  @apply bg-gradient-to-r from-orange-400 to-orange-500;
+}
+.gradient-orange-text {
+  @apply bg-gradient-to-r from-orange-400 to-orange-500 bg-clip-text text-transparent;
+}
+⌨️ KEYBOARD SHORTCUTS
+typescript
+123456789101112131415161718
+// lib/constants/keyboard-shortcuts.ts
+export const KEYBOARD_SHORTCUTS = {
+  'Delete|Backspace': { action: 'delete-selected', description: 'Remove selected nodes/edges' },
+  'Mod+C': { action: 'copy', description: 'Copy selected nodes' },
+  'Mod+V': { action: 'paste', description: 'Paste copied nodes' },
+  'Mod+D': { action: 'duplicate', description: 'Duplicate selected' },
+  'Mod+Z': { action: 'undo', description: 'Undo last action' },
+  'Mod+Shift+Z': { action: 'redo', description: 'Redo' },
+ 
+✅ IMPLEMENTATION CHECKLIST
+Phase 1: Foundation
+Initialize Next.js 14 + TypeScript + Tailwind
+Install dependencies: reactflow, framer-motion, zustand, @phosphor-icons/react
+Configure fonts: Dynapuff (display), DM Mono (code) via next/font
+Set up tailwind.config.js with dark theme colors + orange gradient
+Implement dot background pattern in globals.css
+Create folder structure as specified
+Phase 2: Layout Shell
+Build CanvasLayout.tsx (3-panel flex container)
+Implement TopToolbar.tsx with gradient buttons + Phosphor icons
+Build LeftSidebar.tsx with collapsible state + component categories
+Build RightSidebar.tsx with chat UI structure
+Add ResizeHandle.tsx for draggable panel borders
+Persist sidebar collapse state to localStorage
+Phase 3: Canvas Core
+Set up React Flow Provider with dark theme overrides
+Create BaseNode.tsx with orange-accented styling
+Implement ServiceNode, DatabaseNode, GatewayNode variants
+Create DefaultEdge.tsx with muted stroke + orange selection
+Add sample architecture nodes on first load
+Implement keyboard shortcuts via useEffect listener
+Phase 4: Component Library
+Build ComponentLibrary.tsx with Phosphor icons
+Implement drag-and-drop from sidebar to canvas (@dnd-kit or HTML5)
+Add search/filter functionality for components
+Create collapsible category sections with animations
+Phase 5: Chat Panel
+Build ChatPanel.tsx with scrollable message history
+Implement ChatMessage.tsx with user/AI styling + markdown support
+Create ChatInput.tsx with auto-resize + attachment handling
+Build SuggestionCard.tsx with diagram/code preview
+Add quick prompt chips with horizontal scroll
+Connect to mock AI API endpoint (placeholder for backend)
+Phase 6: State & Persistence
+Set up Zustand stores (canvas + chat) with TypeScript
+Implement localStorage persistence with partialize
+Add undo/redo history tracking
+Connect save/load diagram functionality
+Phase 7: Polish & QA
+Add Framer Motion animations (sidebar, messages, nodes)
+Implement all hover/active/focus states with orange accents
+Add toast notifications (sonner or react-hot-toast)
+Test responsive behavior (min 1280px width)
+Performance: memoize heavy components, virtualize long lists
+Accessibility: keyboard nav, ARIA labels, contrast checks
+Lighthouse audit target: >90 performance, >95 accessibility
+📦 REQUIRED DEPENDENCIES
+json
+12345678910111213141516171819202122232425262728293031
+{
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "reactflow": "^11.11.3",
+    "framer-motion": "^11.1.7",
+    "zustand": "^4.5.2",
+    "@phosphor-icons/react": "^2.1.7",
+    "@radix-ui/react-dialog": "^1.0.5",
+
+🎯 QUALITY REQUIREMENTS
+Performance: Canvas handles 100+ nodes at 60fps; memoize node renders
+Accessibility: WCAG 2.1 AA (contrast ratio 4.5:1 for text, keyboard nav, ARIA)
+Responsiveness: Desktop-first, min 1280px width; graceful degradation to 1024px
+Browser Support: Chrome, Firefox, Safari, Edge (last 2 versions)
+Code Quality: TypeScript strict mode, ESLint + Prettier, no any types
+Testing: Unit tests for utils/hooks; integration tests for canvas interactions
+🚀 STARTING INSTRUCTIONS
+Install dependencies from package list above
+Configure fonts in app/layout.tsx (Dynapuff + DM Mono via next/font)
+Update tailwind.config.js with dark theme colors + orange gradient
+Implement dot background in globals.css and verify visual subtlety
+Build CanvasLayout.tsx shell (3-panel flex) with collapsible sidebars
+Integrate React Flow in CanvasArea.tsx with dark theme overrides
+Build LeftSidebar component library with Phosphor icons + drag-and-drop
+Build RightSidebar chat UI with message history + input
+Connect Zustand stores for canvas + chat state management
+Add Framer Motion animations and interactive states
+Test thoroughly, optimize performance, then deploy

--- a/components/canvas/CanvasArea.tsx
+++ b/components/canvas/CanvasArea.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useCallback, useMemo, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  Node,
+  Edge,
+  ConnectionMode,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+  Connection,
+  ReactFlowInstance,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+import ServiceNode from './nodes/ServiceNode';
+import DatabaseNode from './nodes/DatabaseNode';
+import GatewayNode from './nodes/GatewayNode';
+import BaseNode from './nodes/BaseNode';
+import { NODE_DEFAULTS } from './nodeDefaults';
+
+const initialNodes: Node[] = [
+  {
+    id: 'gateway-1',
+    type: 'gateway',
+    position: { x: 250, y: 50 },
+    data: { label: 'API Gateway', type: 'API Gateway', routes: '12 routes', rateLimit: '1000 req/min' },
+  },
+  {
+    id: 'service-1',
+    type: 'service',
+    position: { x: 100, y: 250 },
+    data: { label: 'Auth Service', language: 'Node.js', port: ':3000', status: 'ok', instances: 2 },
+  },
+  {
+    id: 'service-2',
+    type: 'service',
+    position: { x: 400, y: 250 },
+    data: { label: 'Payment Service', language: 'Go', port: ':8080', status: 'ok', instances: 3 },
+  },
+  {
+    id: 'db-1',
+    type: 'database',
+    position: { x: 100, y: 450 },
+    data: { label: 'Users DB', type: 'PostgreSQL', connection: 'postgres://...', storage: '50GB', replicas: '1 primary' },
+  },
+  {
+    id: 'db-2',
+    type: 'database',
+    position: { x: 400, y: 450 },
+    data: { label: 'Cache', type: 'Redis', connection: 'redis://...', storage: '2GB', replicas: '1 node' },
+  },
+];
+
+const initialEdges: Edge[] = [
+  { id: 'e1-2', source: 'gateway-1', target: 'service-1', animated: true, style: { stroke: '#a3a3a3' } },
+  { id: 'e1-3', source: 'gateway-1', target: 'service-2', animated: true, style: { stroke: '#a3a3a3' } },
+  { id: 'e2-4', source: 'service-1', target: 'db-1', style: { stroke: '#a3a3a3' } },
+  { id: 'e3-5', source: 'service-2', target: 'db-2', style: { stroke: '#a3a3a3', strokeDasharray: '5,5' } },
+];
+
+export default function CanvasArea() {
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
+
+  const onConnect = useCallback(
+    (params: Connection) => setEdges((eds) => addEdge({ ...params, style: { stroke: '#a3a3a3' } }, eds)),
+    [setEdges],
+  );
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+
+      const typeLabel = event.dataTransfer.getData('application/reactflow');
+
+      if (typeof typeLabel === 'undefined' || !typeLabel || !reactFlowInstance) {
+        return;
+      }
+
+      const position = reactFlowInstance.screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      let nodeType = 'base';
+      let nodeData: Record<string, unknown> = { label: typeLabel };
+
+      if (NODE_DEFAULTS[typeLabel]) {
+        const config = NODE_DEFAULTS[typeLabel];
+        nodeType = config.type;
+        nodeData = { ...config.data };
+      } else {
+        // Fallback for legacy items if any
+        if (['Server', 'Function', 'Container'].includes(typeLabel)) {
+          nodeType = 'service';
+          nodeData = { ...nodeData, language: 'Node.js', port: ':8080', status: 'ok', instances: 1 };
+        } else if (['PostgreSQL', 'Redis', 'S3 Bucket', 'Table'].includes(typeLabel)) {
+          nodeType = 'database';
+          nodeData = { ...nodeData, type: typeLabel, connection: 'conn://...', storage: '10GB', replicas: '1' };
+        } else if (['API Gateway', 'Load Balancer', 'Firewall'].includes(typeLabel)) {
+          nodeType = 'gateway';
+          nodeData = { ...nodeData, type: typeLabel, routes: '0', rateLimit: '1000' };
+        }
+      }
+
+      const newNode: Node = {
+        id: `${nodeType}-${Date.now()}`,
+        type: nodeType,
+        position,
+        data: nodeData,
+      };
+
+      setNodes((nds) => nds.concat(newNode));
+    },
+    [reactFlowInstance, setNodes],
+  );
+
+  const nodeTypes = useMemo(() => ({
+    service: ServiceNode,
+    database: DatabaseNode,
+    gateway: GatewayNode,
+    base: BaseNode,
+  }), []);
+
+  return (
+    <div className="flex-1 h-full w-full bg-background bg-dot-pattern relative">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        onInit={setReactFlowInstance}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        nodeTypes={nodeTypes}
+        connectionMode={ConnectionMode.Loose}
+        fitView
+        className="bg-transparent"
+        defaultEdgeOptions={{
+            style: { stroke: '#a3a3a3', strokeWidth: 2 },
+            animated: true,
+        }}
+      >
+        <Background color="transparent" />
+        <Controls className="!bg-card-bg !border-border-dark !text-muted [&>button]:!border-border-dark [&>button:hover]:!bg-border-dark [&>button:hover]:!text-foreground" />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/components/canvas/CanvasLayout.tsx
+++ b/components/canvas/CanvasLayout.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import LeftSidebar from "./LeftSidebar";
+import RightSidebar from "./RightSidebar";
+import TopToolbar from "./TopToolbar";
+import CanvasArea from "./CanvasArea";
+import { CaretLeft } from "@phosphor-icons/react";
+
+export default function CanvasLayout() {
+  const [leftSidebarOpen, setLeftSidebarOpen] = useState(true);
+  const [rightSidebarOpen, setRightSidebarOpen] = useState(true);
+  const [leftWidth] = useState(280);
+  const [rightWidth] = useState(380);
+
+  // Persist state
+  useEffect(() => {
+    const savedLeft = localStorage.getItem("canvas-left-sidebar");
+    const savedRight = localStorage.getItem("canvas-right-sidebar");
+    if (savedLeft) setLeftSidebarOpen(savedLeft === "true");
+    if (savedRight) setRightSidebarOpen(savedRight === "true");
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("canvas-left-sidebar", leftSidebarOpen.toString());
+  }, [leftSidebarOpen]);
+
+  useEffect(() => {
+    localStorage.setItem("canvas-right-sidebar", rightSidebarOpen.toString());
+  }, [rightSidebarOpen]);
+
+  return (
+    <div className="flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground">
+      <TopToolbar />
+      <div className="flex flex-1 overflow-hidden relative">
+        <LeftSidebar 
+          isOpen={leftSidebarOpen} 
+          toggle={() => setLeftSidebarOpen(!leftSidebarOpen)} 
+          width={leftWidth}
+        />
+        
+        {/* Resize Handle Left */}
+        {/* TODO: Implement drag to resize */}
+        
+        <CanvasArea />
+        
+        {/* Resize Handle Right */}
+        {/* TODO: Implement drag to resize */}
+
+        <RightSidebar 
+          isOpen={rightSidebarOpen} 
+          toggle={() => setRightSidebarOpen(!rightSidebarOpen)}
+          width={rightWidth}
+        />
+
+        {!rightSidebarOpen && (
+          <button 
+            onClick={() => setRightSidebarOpen(true)}
+            className="absolute right-4 top-4 z-50 p-2 bg-card-bg border border-border-dark rounded-full text-foreground shadow-lg hover:text-orange-400 transition-colors"
+          >
+            <CaretLeft size={20} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/canvas/LeftSidebar.tsx
+++ b/components/canvas/LeftSidebar.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { 
+  CaretLeft, 
+  CaretRight, 
+  MagnifyingGlass, 
+  CaretDown,
+  Cloud,
+  Cpu,
+  Lightning,
+  Database,
+  Globe,
+  Shield,
+  HardDrives,
+  Cube,
+  Scales,
+  Browsers,
+  Clock,
+  Files,
+  Warehouse,
+  Queue,
+  Broadcast,
+  Waves,
+  Envelope,
+  TreeStructure,
+  ArrowsLeftRight,
+  IdentificationCard,
+  Key,
+  Wall,
+  Certificate,
+  Scroll,
+  ChartLine,
+  Binoculars,
+  User,
+  Plugs
+} from "@phosphor-icons/react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface SidebarProps {
+  isOpen: boolean;
+  toggle: () => void;
+  width?: number;
+}
+
+export default function LeftSidebar({ isOpen, toggle, width = 280 }: SidebarProps) {
+  const [activeCategory, setActiveCategory] = useState<string | null>("compute");
+
+  const categories = [
+    {
+      id: "compute",
+      label: "Compute & Logic",
+      icon: <Cpu size={20} />,
+      items: [
+        { label: "Load Balancer", icon: <Scales size={16} /> },
+        { label: "API Gateway", icon: <Shield size={16} /> },
+        { label: "Microservice", icon: <Cube size={16} /> },
+        { label: "Serverless Function", icon: <Lightning size={16} /> },
+        { label: "Monolith App", icon: <Browsers size={16} /> },
+        { label: "Scheduler/Worker", icon: <Clock size={16} /> },
+      ]
+    },
+    {
+      id: "data",
+      label: "Data & Storage",
+      icon: <Database size={20} />,
+      items: [
+        { label: "Relational DB", icon: <Database size={16} /> },
+        { label: "NoSQL DB", icon: <Files size={16} /> },
+        { label: "Cache", icon: <Lightning size={16} /> },
+        { label: "Object Storage", icon: <HardDrives size={16} /> },
+        { label: "Data Warehouse", icon: <Warehouse size={16} /> },
+        { label: "Search Engine", icon: <MagnifyingGlass size={16} /> },
+      ]
+    },
+    {
+      id: "messaging",
+      label: "Messaging & Streaming",
+      icon: <Broadcast size={20} />,
+      items: [
+        { label: "Message Queue", icon: <Queue size={16} /> },
+        { label: "Pub/Sub Topic", icon: <Broadcast size={16} /> },
+        { label: "Event Stream", icon: <Waves size={16} /> },
+        { label: "Email Service", icon: <Envelope size={16} /> },
+      ]
+    },
+    {
+      id: "network",
+      label: "Network & Edge",
+      icon: <Globe size={20} />,
+      items: [
+        { label: "VPC / Network", icon: <Globe size={16} /> },
+        { label: "Subnet", icon: <TreeStructure size={16} /> },
+        { label: "CDN", icon: <Cloud size={16} /> },
+        { label: "DNS / Domain", icon: <Globe size={16} /> },
+        { label: "NAT Gateway", icon: <ArrowsLeftRight size={16} /> },
+      ]
+    },
+    {
+      id: "security",
+      label: "Security & Identity",
+      icon: <Shield size={20} />,
+      items: [
+        { label: "Identity Provider", icon: <IdentificationCard size={16} /> },
+        { label: "Secrets Manager", icon: <Key size={16} /> },
+        { label: "WAF", icon: <Wall size={16} /> },
+        { label: "Certificate / SSL", icon: <Certificate size={16} /> },
+      ]
+    },
+    {
+      id: "observability",
+      label: "Observability",
+      icon: <ChartLine size={20} />,
+      items: [
+        { label: "Logging Service", icon: <Scroll size={16} /> },
+        { label: "Metrics / Monitoring", icon: <ChartLine size={16} /> },
+        { label: "Tracing", icon: <Binoculars size={16} /> },
+      ]
+    },
+    {
+      id: "external",
+      label: "External & Users",
+      icon: <User size={20} />,
+      items: [
+        { label: "End User / Client", icon: <User size={16} /> },
+        { label: "3rd Party API", icon: <Plugs size={16} /> },
+      ]
+    }
+  ];
+
+  return (
+    <motion.div
+      initial={false}
+      animate={{ width: isOpen ? width : 64 }}
+      transition={{ duration: 0.3, ease: "easeInOut" }}
+      className="flex h-full flex-col border-r border-border-dark bg-card-bg transition-all overflow-hidden z-40 relative"
+    >
+      {/* Header */}
+      <div className="flex h-14 items-center justify-between px-4 border-b border-border-dark shrink-0">
+        <AnimatePresence mode="wait">
+          {isOpen && (
+            <motion.span
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="font-display font-medium text-foreground whitespace-nowrap"
+            >
+              Components
+            </motion.span>
+          )}
+        </AnimatePresence>
+        <button
+          onClick={toggle}
+          className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-orange-400 transition-colors"
+        >
+          {isOpen ? <CaretLeft size={16} /> : <CaretRight size={16} />}
+        </button>
+      </div>
+
+      {/* Search */}
+      <div className={`p-4 transition-all duration-300 ${isOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}>
+        <div className="relative">
+          <MagnifyingGlass size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
+          <input
+            type="text"
+            placeholder="Search components..."
+            className="w-full bg-background border border-border-dark rounded-md py-1.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:border-orange-400 transition-colors"
+          />
+        </div>
+      </div>
+
+      {/* Categories */}
+      <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-border-dark scrollbar-track-transparent">
+        {categories.map((category) => (
+          <div key={category.id} className="border-b border-border-dark/50">
+            <button
+              onClick={() => setActiveCategory(activeCategory === category.id ? null : category.id)}
+              className={`flex w-full items-center justify-between px-4 py-3 hover:bg-border-dark/50 transition-colors ${
+                !isOpen && "justify-center px-2"
+              }`}
+              title={!isOpen ? category.label : undefined}
+            >
+              <div className="flex items-center gap-3 text-sm font-medium text-muted hover:text-foreground">
+                <span className={`${activeCategory === category.id ? "text-orange-400" : ""}`}>
+                  {category.icon}
+                </span>
+                {isOpen && <span>{category.label}</span>}
+              </div>
+              {isOpen && (
+                <CaretDown
+                  size={14}
+                  className={`text-muted transition-transform duration-200 ${
+                    activeCategory === category.id ? "rotate-180" : ""
+                  }`}
+                />
+              )}
+            </button>
+            
+            <AnimatePresence>
+              {isOpen && activeCategory === category.id && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  className="overflow-hidden bg-background/50"
+                >
+                  <div className="px-4 pb-3 pt-1 space-y-1">
+                    {category.items.map((item) => (
+                      <div
+                        key={item.label}
+                        className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-border-dark cursor-grab active:cursor-grabbing group transition-colors"
+                        draggable
+                        onDragStart={(e) => {
+                          e.dataTransfer.setData("application/reactflow", item.label);
+                          e.dataTransfer.effectAllowed = "move";
+                        }}
+                      >
+                        <span className="text-muted group-hover:text-orange-400 transition-colors">
+                          {item.icon}
+                        </span>
+                        <span className="text-sm text-muted group-hover:text-foreground transition-colors">
+                          {item.label}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/canvas/RightSidebar.tsx
+++ b/components/canvas/RightSidebar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { 
+  CaretRight, 
+  Trash, 
+  Gear, 
+  PaperPlaneRight,
+  CheckCircle
+} from "@phosphor-icons/react";
+import { motion } from "framer-motion";
+
+interface SidebarProps {
+  isOpen: boolean;
+  toggle: () => void;
+  width?: number;
+}
+
+export default function RightSidebar({ isOpen, toggle, width = 380 }: SidebarProps) {
+  const [message, setMessage] = useState("");
+  
+  return (
+    <motion.div
+      initial={false}
+      animate={{ width: isOpen ? width : 0 }}
+      transition={{ duration: 0.3, ease: "easeInOut" }}
+      className="flex h-full flex-col border-l border-border-dark bg-card-bg overflow-hidden z-40 relative"
+    >
+      {/* Header */}
+      <div className="flex h-14 items-center justify-between px-4 border-b border-border-dark shrink-0">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={toggle}
+            className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-orange-400 transition-colors"
+          >
+            <CaretRight size={16} className={!isOpen ? "rotate-180" : ""} />
+          </button>
+          <span className="font-display font-medium text-foreground">AI Assistant</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-red-400 transition-colors" title="Clear History">
+            <Trash size={16} />
+          </button>
+          <button className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-orange-400 transition-colors" title="Settings">
+            <Gear size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Chat History */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-thin scrollbar-thumb-border-dark scrollbar-track-transparent">
+        {/* Placeholder for chat messages */}
+        <div className="flex flex-col gap-2">
+          <div className="bg-background border border-border-dark rounded-lg rounded-tl-none p-3 max-w-[90%] self-start">
+            <p className="text-sm text-foreground font-display">
+              Hello! I&apos;m Supabricx AI. How can I help you design your architecture today?
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Chat Input */}
+      <div className="p-4 border-t border-border-dark bg-card-bg">
+        <div className="relative">
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Describe your architecture..."
+            className="w-full bg-background border border-border-dark rounded-lg p-3 pr-12 text-sm font-mono text-foreground placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-orange-400 resize-none min-h-[80px]"
+          />
+          <button
+            className="absolute bottom-3 right-3 p-2 bg-gradient-to-r from-orange-400 to-orange-500 rounded-md text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+            disabled={!message.trim()}
+          >
+            <PaperPlaneRight size={16} weight="bold" />
+          </button>
+        </div>
+        <div className="flex justify-between items-center mt-2 px-1">
+          <span className="text-xs text-muted font-mono">{message.length} chars</span>
+          <div className="flex items-center gap-1 text-xs text-muted">
+            <CheckCircle size={12} className="text-green-500" />
+            <span>Ready</span>
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/canvas/TopToolbar.tsx
+++ b/components/canvas/TopToolbar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowUUpLeft, ArrowUUpRight, Plus, Minus, DotsThreeVertical } from "@phosphor-icons/react";
+
+export default function TopToolbar() {
+  const [title, setTitle] = useState("Untitled Diagram");
+  const [saveStatus] = useState<"saved" | "saving" | "unsaved">("saved");
+
+  return (
+    <div className="flex h-14 w-full items-center justify-between border-b border-border-dark bg-card-bg/80 backdrop-blur-md px-4 z-50">
+      {/* Left Section */}
+      <div className="flex items-center gap-4">
+        <div className="font-display text-xl font-bold gradient-orange-text">
+          Supabricx
+        </div>
+        <div className="h-6 w-px bg-border-dark" />
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="bg-transparent font-mono text-sm text-foreground focus:outline-none w-40"
+            placeholder="Untitled Diagram"
+          />
+          <div className={`h-2 w-2 rounded-full ${
+            saveStatus === "saved" ? "bg-green-500" : 
+            saveStatus === "saving" ? "bg-orange-500" : "bg-gray-500"
+          }`} />
+        </div>
+      </div>
+
+      {/* Center Section */}
+      <div className="flex items-center gap-2 rounded-lg bg-background p-1 border border-border-dark">
+        <button className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-foreground transition-colors">
+          <ArrowUUpLeft size={16} />
+        </button>
+        <button className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-foreground transition-colors">
+          <ArrowUUpRight size={16} />
+        </button>
+        <div className="h-4 w-px bg-border-dark mx-1" />
+        <button className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-foreground transition-colors">
+          <Minus size={16} />
+        </button>
+        <span className="text-xs font-mono text-muted w-12 text-center">100%</span>
+        <button className="p-1.5 hover:bg-border-dark rounded text-muted hover:text-foreground transition-colors">
+          <Plus size={16} />
+        </button>
+      </div>
+
+      {/* Right Section */}
+      <div className="flex items-center gap-3">
+        {/* Placeholder for user/menu */}
+        <button className="p-2 hover:bg-border-dark rounded-full text-muted hover:text-foreground transition-colors">
+          <DotsThreeVertical size={20} weight="bold" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/canvas/nodeDefaults.ts
+++ b/components/canvas/nodeDefaults.ts
@@ -1,0 +1,141 @@
+export interface NodeDefaultConfig {
+  type: 'service' | 'database' | 'gateway' | 'base';
+  data: Record<string, unknown>;
+  icon?: unknown; // We store the icon component or name here if needed for sidebar
+}
+
+export const NODE_DEFAULTS: Record<string, NodeDefaultConfig> = {
+  // Compute & Logic
+  "Load Balancer": {
+    type: "gateway",
+    data: { label: "Load Balancer", type: "Load Balancer", routes: "5 targets", rateLimit: "Unlimited" }
+  },
+  "API Gateway": {
+    type: "gateway",
+    data: { label: "API Gateway", type: "API Gateway", routes: "12 routes", rateLimit: "1000 req/min" }
+  },
+  "Microservice": {
+    type: "service",
+    data: { label: "Microservice", language: "Node.js", port: ":8080", status: "ok", instances: 1 }
+  },
+  "Serverless Function": {
+    type: "service",
+    data: { label: "Lambda Function", language: "Python", port: "-", status: "ok", instances: "Auto" }
+  },
+  "Monolith App": {
+    type: "service",
+    data: { label: "Monolith", language: "Java", port: ":8000", status: "ok", instances: 1 }
+  },
+  "Scheduler/Worker": {
+    type: "service",
+    data: { label: "Worker", language: "Go", port: "-", status: "ok", instances: 1 }
+  },
+
+  // Data & Storage
+  "Relational DB": {
+    type: "database",
+    data: { label: "PostgreSQL", type: "Relational", connection: "postgres://...", storage: "100GB", replicas: "1 primary" }
+  },
+  "NoSQL DB": {
+    type: "database",
+    data: { label: "MongoDB", type: "NoSQL", connection: "mongodb://...", storage: "500GB", replicas: "3 nodes" }
+  },
+  "Cache": {
+    type: "database",
+    data: { label: "Redis", type: "Cache", connection: "redis://...", storage: "5GB", replicas: "1 node" }
+  },
+  "Object Storage": {
+    type: "database",
+    data: { label: "S3 Bucket", type: "Storage", connection: "s3://my-bucket", storage: "Unlimited", replicas: "Multi-AZ" }
+  },
+  "Data Warehouse": {
+    type: "database",
+    data: { label: "Snowflake", type: "Warehouse", connection: "jdbc:snowflake...", storage: "10TB", replicas: "Cluster" }
+  },
+  "Search Engine": {
+    type: "database",
+    data: { label: "Elasticsearch", type: "Search", connection: "http://es:9200", storage: "2TB", replicas: "3 nodes" }
+  },
+
+  // Messaging & Streaming
+  "Message Queue": {
+    type: "base",
+    data: { label: "RabbitMQ", properties: { Type: "Queue", Protocol: "AMQP", Retention: "7 days" } }
+  },
+  "Pub/Sub Topic": {
+    type: "base",
+    data: { label: "Kafka Topic", properties: { Type: "Topic", Partitions: "3", Retention: "7 days" } }
+  },
+  "Event Stream": {
+    type: "base",
+    data: { label: "Kinesis Stream", properties: { Type: "Stream", Shards: "2", Retention: "24h" } }
+  },
+  "Email Service": {
+    type: "base",
+    data: { label: "SES / SendGrid", properties: { Type: "Email", Rate: "10k/day", DedicatedIP: "No" } }
+  },
+
+  // Network & Edge
+  "VPC / Network": {
+    type: "base",
+    data: { label: "VPC", properties: { CIDR: "10.0.0.0/16", Region: "us-east-1", Tenancy: "Default" } }
+  },
+  "Subnet": {
+    type: "base",
+    data: { label: "Public Subnet", properties: { CIDR: "10.0.1.0/24", AZ: "us-east-1a", Public: "Yes" } }
+  },
+  "CDN": {
+    type: "gateway",
+    data: { label: "CloudFront", type: "CDN", routes: "Global", rateLimit: "WAF Enabled" }
+  },
+  "DNS / Domain": {
+    type: "base",
+    data: { label: "Route53", properties: { Zone: "example.com", Records: "15", Type: "Public" } }
+  },
+  "NAT Gateway": {
+    type: "gateway",
+    data: { label: "NAT Gateway", type: "NAT", routes: "Outbound", rateLimit: "45Gbps" }
+  },
+
+  // Security & Identity
+  "Identity Provider": {
+    type: "base",
+    data: { label: "Auth0 / Cognito", properties: { Type: "IdP", Users: "5000+", MFA: "Enabled" } }
+  },
+  "Secrets Manager": {
+    type: "base",
+    data: { label: "Vault", properties: { Type: "Secrets", Encryption: "AES-256", Rotation: "30 days" } }
+  },
+  "WAF": {
+    type: "gateway",
+    data: { label: "WAF", type: "Firewall", routes: "All Traffic", rateLimit: "Block Bad Bot" }
+  },
+  "Certificate / SSL": {
+    type: "base",
+    data: { label: "ACM Cert", properties: { Type: "SSL/TLS", Domain: "*.app.com", Expires: "365 days" } }
+  },
+
+  // Observability
+  "Logging Service": {
+    type: "base",
+    data: { label: "CloudWatch / ELK", properties: { Type: "Logs", Retention: "30 days", Index: "Daily" } }
+  },
+  "Metrics / Monitoring": {
+    type: "base",
+    data: { label: "Prometheus", properties: { Type: "Metrics", Scrape: "15s", Retention: "15 days" } }
+  },
+  "Tracing": {
+    type: "base",
+    data: { label: "Jaeger / X-Ray", properties: { Type: "Tracing", Sample: "10%", Storage: "Elastic" } }
+  },
+
+  // External & Users
+  "End User / Client": {
+    type: "base",
+    data: { label: "Web Browser", properties: { Platform: "Web/Mobile", Auth: "JWT", Region: "Global" } }
+  },
+  "3rd Party API": {
+    type: "base",
+    data: { label: "Stripe API", properties: { Type: "External", Auth: "API Key", RateLimit: "Yes" } }
+  }
+};

--- a/components/canvas/nodes/BaseNode.tsx
+++ b/components/canvas/nodes/BaseNode.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import { DotsThreeVertical } from "@phosphor-icons/react";
+
+interface BaseNodeData {
+  label: string;
+  icon?: React.ReactNode;
+  properties?: Record<string, string>;
+  type?: string;
+}
+
+const BaseNode = ({ data, selected }: NodeProps<BaseNodeData>) => {
+  return (
+    <div className={`w-[200px] rounded-lg border bg-card-bg shadow-lg transition-all ${selected ? 'border-orange-400 ring-1 ring-orange-400' : 'border-border-dark'}`}>
+      {/* Header */}
+      <div className="flex h-8 items-center justify-between rounded-t-lg bg-gradient-to-r from-orange-400 to-orange-500 px-2">
+        <div className="flex items-center gap-2">
+          {data.icon && <span className="text-white">{data.icon}</span>}
+          <span className="font-display text-xs font-bold text-white truncate max-w-[120px]">
+            {data.label}
+          </span>
+        </div>
+        <button className="text-white/80 hover:text-white">
+          <DotsThreeVertical size={16} weight="bold" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="bg-background p-3 rounded-b-lg">
+        {data.properties && (
+          <div className="space-y-1">
+            {Object.entries(data.properties).map(([key, value]) => (
+              <div key={key} className="flex justify-between text-xs font-mono">
+                <span className="text-muted">{key}:</span>
+                <span className="text-foreground truncate max-w-[100px]" title={value}>
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Handles */}
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-muted !w-3 !h-3 !border-2 !border-background"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-muted !w-3 !h-3 !border-2 !border-background"
+      />
+    </div>
+  );
+};
+
+export default memo(BaseNode);

--- a/components/canvas/nodes/DatabaseNode.tsx
+++ b/components/canvas/nodes/DatabaseNode.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import { Database, DotsThreeVertical, Cylinder } from "@phosphor-icons/react";
+
+const DatabaseNode = ({ data, selected }: NodeProps) => {
+  return (
+    <div className={`w-[220px] rounded-lg border bg-card-bg shadow-lg transition-all ${selected ? 'border-orange-400 ring-1 ring-orange-400' : 'border-border-dark'}`}>
+      {/* Header */}
+      <div className="flex h-8 items-center justify-between rounded-t-lg bg-gradient-to-r from-orange-400 to-orange-500 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <Database size={16} className="text-white" weight="bold" />
+          <span className="font-display text-xs font-bold text-white truncate max-w-[140px]">
+            {data.label || "Database"}
+          </span>
+        </div>
+        <button className="text-white/80 hover:text-white">
+          <DotsThreeVertical size={16} weight="bold" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="bg-background p-3 rounded-b-lg relative overflow-hidden">
+        {/* Decorative Icon */}
+        <Cylinder size={48} className="absolute -bottom-2 -right-2 text-muted opacity-5 rotate-12" />
+
+        <div className="space-y-2 relative z-10">
+          {/* Type Badge */}
+          <div className="flex justify-between items-center">
+             <span className="text-xs font-mono text-muted">Type:</span>
+             <span className="text-xs font-mono px-1.5 py-0.5 rounded border border-orange-500/30 text-orange-400 bg-orange-500/10">
+               {data.type || "PostgreSQL"}
+             </span>
+          </div>
+
+          {/* Connection */}
+          <div className="flex justify-between text-xs font-mono">
+            <span className="text-muted">Conn:</span>
+            <span className="text-foreground font-mono bg-border-dark/50 px-1 rounded truncate max-w-[100px]" title={data.connection}>
+              {data.connection || "postgres://***"}
+            </span>
+          </div>
+
+          {/* Storage */}
+          <div className="flex justify-between text-xs font-mono items-center">
+            <span className="text-muted">Storage:</span>
+            <span className="text-foreground">{data.storage || "50GB"}</span>
+          </div>
+
+          {/* Replicas */}
+          <div className="flex justify-between text-xs font-mono">
+             <span className="text-muted">Repl:</span>
+             <span className="bg-border-dark px-1.5 rounded text-foreground">
+               {data.replicas || "1 primary + 2 read"}
+             </span>
+          </div>
+        </div>
+      </div>
+
+      <Handle type="target" position={Position.Top} className="!bg-muted !w-3 !h-3 !border-2 !border-background" />
+      <Handle type="source" position={Position.Bottom} className="!bg-muted !w-3 !h-3 !border-2 !border-background" />
+    </div>
+  );
+};
+
+export default memo(DatabaseNode);

--- a/components/canvas/nodes/GatewayNode.tsx
+++ b/components/canvas/nodes/GatewayNode.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import { Shield, DotsThreeVertical, ArrowRight, Pulse, Globe } from "@phosphor-icons/react";
+
+const GatewayNode = ({ data, selected }: NodeProps) => {
+  return (
+    <div className={`w-[220px] rounded-lg border bg-card-bg shadow-lg transition-all ${selected ? 'border-orange-400 ring-1 ring-orange-400' : 'border-border-dark'}`}>
+      {/* Header */}
+      <div className="flex h-8 items-center justify-between rounded-t-lg bg-gradient-to-r from-orange-400 to-orange-500 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <Shield size={16} className="text-white" weight="bold" />
+          <span className="font-display text-xs font-bold text-white truncate max-w-[140px]">
+            {data.label || "API Gateway"}
+          </span>
+        </div>
+        <button className="text-white/80 hover:text-white">
+          <DotsThreeVertical size={16} weight="bold" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="bg-background p-3 rounded-b-lg relative overflow-hidden">
+        {/* Decorative Icon */}
+        <Globe size={48} className="absolute -bottom-2 -right-2 text-muted opacity-5 rotate-12" />
+
+        <div className="space-y-2 relative z-10">
+          {/* Type Badge */}
+          <div className="flex justify-between items-center">
+             <span className="text-xs font-mono text-muted">Type:</span>
+             <span className="text-xs font-mono px-1.5 py-0.5 rounded border border-orange-500/30 text-orange-400 bg-orange-500/10">
+               {data.type || "API Gateway"}
+             </span>
+          </div>
+
+          {/* Rules */}
+          <div className="flex justify-between text-xs font-mono">
+            <span className="text-muted">Rules:</span>
+            <div className="flex items-center gap-1">
+              <ArrowRight size={12} className="text-muted" />
+              <span className="text-foreground">{data.routes || "12 routes"}</span>
+            </div>
+          </div>
+
+          {/* Rate Limit */}
+          <div className="flex justify-between text-xs font-mono items-center">
+            <span className="text-muted">Rate Limit:</span>
+            <div className="flex items-center gap-1">
+              <Pulse size={12} className="text-orange-400" />
+              <span className="text-foreground">{data.rateLimit || "1000 req/min"}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Handle type="target" position={Position.Top} className="!bg-muted !w-3 !h-3 !border-2 !border-background" />
+      <Handle type="source" position={Position.Bottom} className="!bg-muted !w-3 !h-3 !border-2 !border-background" />
+    </div>
+  );
+};
+
+export default memo(GatewayNode);

--- a/components/canvas/nodes/ServiceNode.tsx
+++ b/components/canvas/nodes/ServiceNode.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import { HardDrives, DotsThreeVertical, Code, CheckCircle, Warning } from "@phosphor-icons/react";
+
+const ServiceNode = ({ data, selected }: NodeProps) => {
+  return (
+    <div className={`w-[220px] rounded-lg border bg-card-bg shadow-lg transition-all ${selected ? 'border-orange-400 ring-1 ring-orange-400' : 'border-border-dark'}`}>
+      {/* Header */}
+      <div className="flex h-8 items-center justify-between rounded-t-lg bg-gradient-to-r from-orange-400 to-orange-500 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <HardDrives size={16} className="text-white" weight="bold" />
+          <span className="font-display text-xs font-bold text-white truncate max-w-[140px]">
+            {data.label || "Microservice"}
+          </span>
+        </div>
+        <button className="text-white/80 hover:text-white">
+          <DotsThreeVertical size={16} weight="bold" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="bg-background p-3 rounded-b-lg relative overflow-hidden">
+        {/* Decorative Icon */}
+        <Code size={48} className="absolute -bottom-2 -right-2 text-muted opacity-10 rotate-12" />
+
+        <div className="space-y-2 relative z-10">
+          {/* Language Badge */}
+          <div className="flex justify-between items-center">
+             <span className="text-xs font-mono text-muted">Lang:</span>
+             <span className="text-xs font-mono px-1.5 py-0.5 rounded border border-orange-500/30 text-orange-400 bg-orange-500/10">
+               {data.language || "Node.js"}
+             </span>
+          </div>
+
+          {/* Port */}
+          <div className="flex justify-between text-xs font-mono">
+            <span className="text-muted">Port:</span>
+            <span className="text-foreground">{data.port || ":8080"}</span>
+          </div>
+
+          {/* Health Status */}
+          <div className="flex justify-between text-xs font-mono items-center">
+            <span className="text-muted">Health:</span>
+            <div className="flex items-center gap-1.5">
+              {data.status === 'degraded' ? (
+                 <Warning size={12} className="text-orange-400" weight="fill" />
+              ) : (
+                 <CheckCircle size={12} className="text-green-500" weight="fill" />
+              )}
+              <span className={data.status === 'degraded' ? "text-orange-400" : "text-green-500"}>
+                {data.status === 'degraded' ? 'Degraded' : 'OK'}
+              </span>
+            </div>
+          </div>
+
+          {/* Instances */}
+          <div className="flex justify-between text-xs font-mono">
+             <span className="text-muted">Replicas:</span>
+             <span className="bg-border-dark px-1.5 rounded text-foreground">
+               x{data.instances || 1}
+             </span>
+          </div>
+        </div>
+      </div>
+
+      <Handle type="target" position={Position.Top} className="!bg-muted !w-3 !h-3 !border-2 !border-background" />
+      <Handle type="source" position={Position.Bottom} className="!bg-muted !w-3 !h-3 !border-2 !border-background" />
+    </div>
+  );
+};
+
+export default memo(ServiceNode);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "next": "15.5.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "reactflow": "^11.11.4",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -912,6 +914,276 @@
         "react-dom": ">= 16.8"
       }
     },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/background/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1203,11 +1475,270 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1234,7 +1765,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2169,6 +2700,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2216,7 +2753,113 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4797,6 +5440,24 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5651,6 +6312,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5779,6 +6449,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "reactflow": "^11.11.4",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/plan.txt
+++ b/plan.txt
@@ -1,0 +1,271 @@
+Build a production-ready homepage for Vexel - an AI-powered architecture design tool for developers. Create a modern, minimalist single-page website with the following specifications:
+
+## 📦 TECH STACK
+- Framework: Next.js (App Router) with TypeScript
+- Styling: Tailwind CSS v4,2+
+- Animations: Framer Motion for smooth transitions
+- Icons: Lucide React
+- Components: Radix UI primitives
+- Fonts: DynaPuff (main), DM Mono (code)
+- Deployment: Vercel-ready
+
+## 🎨 DESIGN SYSTEM
+
+### Colors (Tailwind Config)
+```javascript
+colors: {
+  background: '#FFFFFF',
+  foreground: '#000000',
+  border: '#E5E5E5',
+  muted: '#737373',
+  'muted-foreground': '#A3A3A3',
+  accent: '#FAFAFA',
+  'accent-foreground': '#000000',
+}   Background Pattern
+Implement subtle DOT pattern (NOT grid lines)
+Dot specs: 1px diameter, #E5E5E5 color, 40% opacity
+Spacing: 24px horizontal and vertical
+Implementation: CSS radial-gradient or SVG pattern
+Should be very subtle and not distracting
+Typography
+Headings: Inter, font-weight 600-700
+Body: Inter, font-weight 400-500
+Code: JetBrains Mono, font-weight 400
+Base size: 16px, scale: 1.25 (major third)
+Spacing Scale
+Use Tailwind's default spacing (4, 8, 12, 16, 20, 24, 32, 48, 64, etc.)
+Section padding: py-20 on desktop, py-12 on mobile
+Container max-width: 1280px (mx-auto)
+🏗️ COMPONENT ARCHITECTURE
+File Structure /app
+  /page.tsx (homepage)
+  /layout.tsx (root layout)
+  /globals.css (global styles with dot pattern)
+/components
+  /ui (reusable UI components)
+    Button.tsx
+    Card.tsx
+    Input.tsx
+    Badge.tsx
+  /layout
+    Header.tsx
+    Footer.tsx
+  /sections
+    HeroSection.tsx
+    FeaturesBentoGrid.tsx
+    UseCasesSection.tsx
+    IntegrationsSection.tsx
+    SocialProofSection.tsx
+    PricingSection.tsx
+    CTASection.tsx
+  /shared
+    DotBackground.tsx
+    BentoCard.tsx
+    SectionHeading.tsx
+/lib
+  /utils.ts (cn helper, etc.)
+/public
+  /images (diagram previews, logos)
+
+📄 PAGE SECTIONS IMPLEMENTATION
+1. Header/Navigation Component
+typescript
+1234567
+// Fixed position, 64px height
+// Left: logo.jpeg in public folder + "Vexel" text
+// Center: Nav links (Features, Pricing, Docs)
+// Right: "Sign In" (ghost button) + "Get Started" (primary button)
+// Border-bottom: 1px border-border
+// Sticky top-0, backdrop-blur-sm, bg-background/80
+// Mobile: hamburger menu (hidden on desktop)
+2. Hero Section
+typescript
+123456789101112131415161718192021
+// Min-height: 90vh, centered content
+// H1: "Design systems. Generate code. Architect intelligently."
+//   - Text-4xl md:text-6xl lg:text-7xl, font-bold, tracking-tight
+//   - Max-w-4xl, text-center
+// Subheading: "AI-powered architecture diagrams..."
+//   - Text-xl md:text-2xl, text-muted-foreground
+//   - Max-w-2xl, text-center, mt-6
+// Diagram Preview Cards (4 cards, overlapping):
+//   - Use absolute positioning with slight rotations
+//   - Card 1: System Architecture (z-30, translate-y-0)
+
+3. Features Bento Grid Section
+typescript
+1234567891011121314151617181920212223
+// Section padding: py-24
+// Heading: "Everything you need to architect better systems"
+//   - Text-3xl md:text-4xl, font-bold, text-center, mb-16
+// Grid: grid grid-cols-1 md:grid-cols-3 gap-6
+// Cards (6 total, varying spans):
+//   Card 1 (col-span-2 row-span-2): "AI Diagram Generation"
+//     - Large card showing chat interface preview
+//   Card 2 (col-span-1): "GitHub Import"
+//     - Icon: GitBranch, title, description
+//   Card 3 (col-span-1): "Code Scaffolding"
+
+4. Use Cases Section
+typescript
+123456789
+// Background: bg-accent/30
+// Grid: grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6
+// 4 cards:
+//   - "Startup CTOs" - "Validate architecture before writing code"
+//   - "Enterprise Architects" - "Document systems with auto-sync"
+//   - "DevOps Engineers" - "Generate infrastructure code"
+//   - "Engineering Managers" - "Onboard team with visual maps"
+// Each card: border, rounded-lg, p-6, bg-background
+// Icon at top, title, description, small quote snippet
+5. Integrations Section
+typescript
+123456789
+// Heading: "Works with your existing stack"
+// Grid: grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4
+// 6 integration cards:
+//   GitHub, GitLab, AWS, Kubernetes, Terraform, VS Code
+// Each card:
+//   - 120x120px, border, rounded-lg, flex center
+//   - Logo (monochrome), name below
+//   - Hover: border-foreground transition
+// Link below: "View all 30+ integrations →"
+6. Social Proof Section
+typescript
+123456
+// Heading: "Trusted by engineering teams at"
+// Logo row: 5-6 company logos (grayscale, opacity-60)
+// Testimonials (3 cards horizontal):
+//   - Quote text, author name, role, company
+//   - Small avatar circle (placeholder)
+//   - Border, rounded-lg, p-6
+7. Pricing Section
+typescript
+1234567891011121314
+// Heading: "Simple, transparent pricing"
+// Grid: grid grid-cols-1 md:grid-cols-3 gap-8
+// 3 pricing cards:
+//   Free: "$0/mo" - 1 project, basic diagrams
+//   Pro: "$19/mo" - Unlimited, AI features (highlighted)
+//     - Border-2 border-foreground, scale-105
+//     - "Most Popular" badge at top
+//   Team: "$49/user/mo" - SSO, audit logs
+// Each card:
+//   - Border, rounded-xl, p-8, bg-background
+
+8. Footer Component
+typescript
+123456
+// Background: bg-foreground, text-background
+// Padding: py-16
+// Grid: grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-8
+// Column 1 (col-span-1): Logo + tagline
+// Columns 2-5: Link groups (Product, Resources, Company, Legal)
+// Bottom row: Copyright + social icons (GitHub, Twitter, LinkedIn)
+🎨 DOT BACKGROUND IMPLEMENTATION
+globals.css
+css
+123456789101112131415161718192021222324252627
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 0%;
+    --border: 0 0% 90%;
+  }
+  
+  body {
+    @apply bg-background text-foreground antialiased;
+    background-image: radial-gradient(circle at 1px 1px, rgba(0,0,0,0.08) 1px, transparent 0);
+
+🎬 ANIMATIONS & INTERACTIONS
+Framer Motion Variants
+typescript
+1234567891011121314151617181920
+// Fade up animation for sections
+const fadeUpVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.6 } }
+};
+
+// Stagger children animation
+const staggerContainer = {
+  hidden: { opacity: 0 },
+  visible: {
+
+Scroll Animations
+Use Intersection Observer or Framer Motion's whileInView
+Trigger fade-up when sections enter viewport
+Smooth scroll behavior (scroll-smooth on html)
+🔧 UTILITIES & HELPERS
+lib/utils.ts
+typescript
+12345678910
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function formatPrice(price: number): string {
+  return `$${price}/mo`;
+}
+📱 RESPONSIVE BREAKPOINTS
+Mobile: < 768px (single column, stacked layout)
+Tablet: 768px - 1024px (2 columns where applicable)
+Desktop: 1024px - 1280px (full layout)
+Large: > 1280px (max-width container)
+✅ IMPLEMENTATION CHECKLIST
+Phase 1: Setup
+Initialize Next.js 14 project with TypeScript
+Configure Tailwind CSS with custom colors
+Install dependencies (framer-motion, lucide-react, radix-ui)
+Set up dot background pattern in globals.css
+Create component folder structure
+Phase 2: Core Components
+Build Header component with navigation
+Build Footer component with links
+Create reusable Button, Card, Input components
+Create DotBackground wrapper component
+Create BentoCard component
+Phase 3: Sections
+Implement HeroSection with diagram previews
+Implement FeaturesBentoGrid (6 cards)
+Implement UseCasesSection (4 cards)
+Implement IntegrationsSection (6 logos)
+Implement SocialProofSection (testimonials)
+Implement PricingSection (3 tiers)
+Implement CTASection (final call-to-action)
+Phase 4: Polish
+Add scroll animations with Framer Motion
+Add hover states and transitions
+Ensure responsive design on all sections
+Test on mobile, tablet, desktop
+Optimize images and assets
+Add loading states
+SEO meta tags and Open Graph
+Phase 5: Final
+Performance audit (Lighthouse)
+Accessibility check (WCAG AA)
+Cross-browser testing
+Deploy to Vercel
+📝 CONTENT & COPY
+Use this exact copy:
+Hero:
+H1: "Design systems. Generate code. Architect intelligently."
+Subheading: "AI-powered architecture diagrams that sync with your codebase. Import from GitHub, SRS docs, or chat with AI."
+CTA: "Generate Diagram"
+Features:
+Section heading: "Everything you need to architect better systems"
+Card titles: "AI Diagram Generation", "GitHub Import", "Code Scaffolding", "Real-time Sync", "Team Collaboration", "Export Anywhere"
+Pricing:
+Free: "$0/mo", "1 project, basic diagrams, community support"
+Pro: "$19/mo", "Unlimited projects, AI features, code export, priority support"
+Team: "$49/user/mo", "SSO, audit logs, custom rules, dedicated support"
+🎯 QUALITY REQUIREMENTS
+Performance: Lighthouse score > 90 on all metrics
+Accessibility: WCAG 2.1 AA compliant
+SEO: Proper meta tags, semantic HTML, structured data
+Responsiveness: Flawless on 320px - 2560px widths
+Browser Support: Chrome, Firefox, Safari, Edge (last 2 versions)
+Code Quality: ESLint + Prettier configured, no warnings


### PR DESCRIPTION
…-drop

- Create 3-panel layout: Component Library, Canvas Area, AI Assistant
- Integrate React Flow for diagramming with custom node types (Service, Database, Gateway)
- Implement comprehensive component library with categorized items (Compute, Data, Network, Security, Observability)
- Add drag-and-drop functionality with smart default properties via nodeDefaults.ts
- Configure Tailwind dark theme with orange accents and dot pattern background
- Update Navbar to link 'Get Started' button to /canvas route
- Add dependencies: reactflow, zustand, framer-motion, @phosphor-icons/react