### PR TITLE
feat(canvas): implement universal node design and properties sidebar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 "use client"
-import { CodeBlockIcon } from "@phosphor-icons/react";
 import Navbar from "./components/Navbar";
 import Features from "@/components/landing/Features";
 import Pricing from "@/components/landing/Pricing";

--- a/components/canvas/CanvasArea.tsx
+++ b/components/canvas/CanvasArea.tsx
@@ -12,45 +12,47 @@ import ReactFlow, {
   addEdge,
   Connection,
   ReactFlowInstance,
+  NodeMouseHandler,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-import ServiceNode from './nodes/ServiceNode';
-import DatabaseNode from './nodes/DatabaseNode';
-import GatewayNode from './nodes/GatewayNode';
-import BaseNode from './nodes/BaseNode';
-import { NODE_DEFAULTS } from './nodeDefaults';
+import UniversalNode from './nodes/UniversalNode';
+import { getNodeConfig } from './constants';
+
+interface CanvasAreaProps {
+  onNodeSelect?: (node: Node | null) => void;
+}
 
 const initialNodes: Node[] = [
   {
     id: 'gateway-1',
-    type: 'gateway',
+    type: 'universal',
     position: { x: 250, y: 50 },
-    data: { label: 'API Gateway', type: 'API Gateway', routes: '12 routes', rateLimit: '1000 req/min' },
+    data: { label: 'API Gateway', iconName: 'Shield', color: '#FF2F9F', type: 'API Gateway', routes: '12 routes', rateLimit: '1000 req/min' },
   },
   {
     id: 'service-1',
-    type: 'service',
+    type: 'universal',
     position: { x: 100, y: 250 },
-    data: { label: 'Auth Service', language: 'Node.js', port: ':3000', status: 'ok', instances: 2 },
+    data: { label: 'Auth Service', iconName: 'Cube', color: '#FF2F9F', language: 'Node.js', port: ':3000', status: 'ok', instances: 2 },
   },
   {
     id: 'service-2',
-    type: 'service',
+    type: 'universal',
     position: { x: 400, y: 250 },
-    data: { label: 'Payment Service', language: 'Go', port: ':8080', status: 'ok', instances: 3 },
+    data: { label: 'Payment Service', iconName: 'Cube', color: '#FF2F9F', language: 'Go', port: ':8080', status: 'ok', instances: 3 },
   },
   {
     id: 'db-1',
-    type: 'database',
+    type: 'universal',
     position: { x: 100, y: 450 },
-    data: { label: 'Users DB', type: 'PostgreSQL', connection: 'postgres://...', storage: '50GB', replicas: '1 primary' },
+    data: { label: 'Users DB', iconName: 'Database', color: '#2FC1FF', imageSrc: '/postgresql.png', type: 'PostgreSQL', connection: 'postgres://...', storage: '50GB', replicas: '1 primary' },
   },
   {
     id: 'db-2',
-    type: 'database',
+    type: 'universal',
     position: { x: 400, y: 450 },
-    data: { label: 'Cache', type: 'Redis', connection: 'redis://...', storage: '2GB', replicas: '1 node' },
+    data: { label: 'Cache', iconName: 'Database', color: '#2FC1FF', imageSrc: '/redis.png', type: 'Redis', connection: 'redis://...', storage: '2GB', replicas: '1 node' },
   },
 ];
 
@@ -61,7 +63,7 @@ const initialEdges: Edge[] = [
   { id: 'e3-5', source: 'service-2', target: 'db-2', style: { stroke: '#a3a3a3', strokeDasharray: '5,5' } },
 ];
 
-export default function CanvasArea() {
+export default function CanvasArea({ onNodeSelect }: CanvasAreaProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
@@ -91,32 +93,21 @@ export default function CanvasArea() {
         y: event.clientY,
       });
 
-      let nodeType = 'base';
-      let nodeData: Record<string, unknown> = { label: typeLabel };
-
-      if (NODE_DEFAULTS[typeLabel]) {
-        const config = NODE_DEFAULTS[typeLabel];
-        nodeType = config.type;
-        nodeData = { ...config.data };
-      } else {
-        // Fallback for legacy items if any
-        if (['Server', 'Function', 'Container'].includes(typeLabel)) {
-          nodeType = 'service';
-          nodeData = { ...nodeData, language: 'Node.js', port: ':8080', status: 'ok', instances: 1 };
-        } else if (['PostgreSQL', 'Redis', 'S3 Bucket', 'Table'].includes(typeLabel)) {
-          nodeType = 'database';
-          nodeData = { ...nodeData, type: typeLabel, connection: 'conn://...', storage: '10GB', replicas: '1' };
-        } else if (['API Gateway', 'Load Balancer', 'Firewall'].includes(typeLabel)) {
-          nodeType = 'gateway';
-          nodeData = { ...nodeData, type: typeLabel, routes: '0', rateLimit: '1000' };
-        }
-      }
-
+      // Get configuration from constants
+      const config = getNodeConfig(typeLabel);
+      
       const newNode: Node = {
-        id: `${nodeType}-${Date.now()}`,
-        type: nodeType,
+        id: `node-${Date.now()}`,
+        type: 'universal',
         position,
-        data: nodeData,
+        data: { 
+          label: typeLabel,
+          iconName: config?.iconName || 'Cube',
+          color: config?.color || '#000000',
+          imageSrc: config?.imageSrc,
+          // Add default properties based on type
+          ...config
+        },
       };
 
       setNodes((nds) => nds.concat(newNode));
@@ -124,11 +115,25 @@ export default function CanvasArea() {
     [reactFlowInstance, setNodes],
   );
 
+  const onNodeClick: NodeMouseHandler = useCallback((event, node) => {
+    if (onNodeSelect) {
+      onNodeSelect(node);
+    }
+  }, [onNodeSelect]);
+
+  const onPaneClick = useCallback(() => {
+    if (onNodeSelect) {
+      onNodeSelect(null);
+    }
+  }, [onNodeSelect]);
+
   const nodeTypes = useMemo(() => ({
-    service: ServiceNode,
-    database: DatabaseNode,
-    gateway: GatewayNode,
-    base: BaseNode,
+    universal: UniversalNode,
+    // Map legacy types to universal node to ensure consistent styling
+    service: UniversalNode,
+    database: UniversalNode,
+    gateway: UniversalNode,
+    base: UniversalNode,
   }), []);
 
   return (
@@ -142,6 +147,8 @@ export default function CanvasArea() {
         onInit={setReactFlowInstance}
         onDrop={onDrop}
         onDragOver={onDragOver}
+        onNodeClick={onNodeClick}
+        onPaneClick={onPaneClick}
         nodeTypes={nodeTypes}
         connectionMode={ConnectionMode.Loose}
         fitView

--- a/components/canvas/CanvasLayout.tsx
+++ b/components/canvas/CanvasLayout.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { Node } from "reactflow";
 import LeftSidebar from "./LeftSidebar";
 import RightSidebar from "./RightSidebar";
+import PropertiesSidebar from "./PropertiesSidebar";
 import TopToolbar from "./TopToolbar";
 import CanvasArea from "./CanvasArea";
 import { CaretLeft } from "@phosphor-icons/react";
@@ -10,6 +12,7 @@ import { CaretLeft } from "@phosphor-icons/react";
 export default function CanvasLayout() {
   const [leftSidebarOpen, setLeftSidebarOpen] = useState(true);
   const [rightSidebarOpen, setRightSidebarOpen] = useState(true);
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [leftWidth] = useState(280);
   const [rightWidth] = useState(380);
 
@@ -39,15 +42,21 @@ export default function CanvasLayout() {
           width={leftWidth}
         />
         
-        <CanvasArea />
+        <CanvasArea onNodeSelect={setSelectedNode} />
         
         <RightSidebar 
-          isOpen={rightSidebarOpen} 
+          isOpen={rightSidebarOpen && !selectedNode} 
           toggle={() => setRightSidebarOpen(!rightSidebarOpen)}
           width={rightWidth}
         />
 
-        {!rightSidebarOpen && (
+        <PropertiesSidebar 
+          isOpen={!!selectedNode} 
+          node={selectedNode} 
+          onClose={() => setSelectedNode(null)} 
+        />
+
+        {!rightSidebarOpen && !selectedNode && (
           <button 
             onClick={() => setRightSidebarOpen(true)}
             className="absolute right-4 top-4 z-50 p-2 bg-card-bg rounded-full text-foreground shadow-lg hover:text-orange-400 transition-colors"

--- a/components/canvas/LeftSidebar.tsx
+++ b/components/canvas/LeftSidebar.tsx
@@ -1,43 +1,14 @@
 "use client";
 
-import Image from "next/image";
 import { useState } from "react";
+import Image from "next/image";
 import { 
-  CaretLeft, 
-  CaretRight, 
-  MagnifyingGlass, 
   CaretDown,
-  Cloud,
-  Cpu,
-  Lightning,
-  Database,
-  Globe,
-  Shield,
-  HardDrives,
-  Cube,
-  Scales,
-  Browsers,
-  Clock,
-  Files,
-  Warehouse,
-  Queue,
-  Broadcast,
-  Waves,
-  Envelope,
-  TreeStructure,
-  ArrowsLeftRight,
-  IdentificationCard,
-  Key,
-  Wall,
-  Certificate,
-  Scroll,
-  ChartLine,
-  Binoculars,
-  User,
+  MagnifyingGlass,
   SidebarIcon,
-  Plugs
 } from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "framer-motion";
+import { NODE_CATEGories, ICON_MAP } from "./constants";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -47,6 +18,7 @@ interface SidebarProps {
 
 export default function LeftSidebar({ isOpen, toggle, width = 280 }: SidebarProps) {
   const [activeCategory, setActiveCategory] = useState<string | null>("compute");
+  
   const iconBg = (hex: string, alpha: number) => {
     const normalized = hex.replace("#", "");
     const full = normalized.length === 3 ? normalized.split("").map((c) => c + c).join("") : normalized;
@@ -55,88 +27,6 @@ export default function LeftSidebar({ isOpen, toggle, width = 280 }: SidebarProp
     const b = Number.parseInt(full.slice(4, 6), 16);
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   };
-
-  const categories = [
-    {
-      id: "compute",
-      label: "Compute & Logic",
-      icon: <Cpu size={25} weight="fill" color="#FF2F9F" />,
-      items: [
-        { label: "Load Balancer", icon: <Scales size={20} color="#FF2F9F" />, color: "#FF2F9F" },
-        { label: "API Gateway", icon: <Shield size={20} color="#FF2F9F" />, color: "#FF2F9F" },
-        { label: "Microservice", icon: <Cube size={20} color="#FF2F9F"/>, color: "#FF2F9F" },
-        { label: "Serverless Function", icon: <Lightning size={20} color="#FF2F9F" />, color: "#FF2F9F" },
-        { label: "Monolith App", icon: <Browsers size={20} color="#FF2F9F" />, color: "#FF2F9F" },
-        { label: "Scheduler/Worker", icon: <Clock size={20} color="#FF2F9F" />, color: "#FF2F9F" },
-      ]
-    },
-    {
-      id: "data",
-      label: "Data & Storage",
-      icon: <Database size={25} weight="fill" color="#2FC1FF"/>,
-      items: [
-        { label: "Relational DB", icon: <Image src="/postgresql.png" alt="PostgreSQL" width={16} height={16} />, color: "#2FC1FF" },
-        { label: "NoSQL DB", icon: <Files size={20} color="#2FC1FF"/>, color: "#2FC1FF" },
-        { label: "Cache", icon: <Image src="/redis.png" alt="Redis" width={16} height={16} />, color: "#2FC1FF" },
-        { label: "Object Storage", icon: <HardDrives size={20} color="#2FC1FF" />, color: "#2FC1FF" },
-        { label: "Data Warehouse", icon: <Warehouse size={20} color="#2FC1FF" />, color: "#2FC1FF" },
-        { label: "Search Engine", icon: <MagnifyingGlass size={20} color="#2FC1FF" />, color: "#2FC1FF" },
-      ]
-    },
-    {
-      id: "messaging",
-      label: "Messaging & Streaming",
-      icon: <Broadcast size={25} weight="fill" color="#BF34D6"/>,
-      items: [
-        { label: "Message Queue", icon: <Queue size={20} color="#BF34D6"/>, color: "#BF34D6" },
-        { label: "Pub/Sub Topic", icon: <Broadcast size={20} color="#BF34D6"/>, color: "#BF34D6" },
-        { label: "Event Stream", icon: <Waves size={20} color="#BF34D6"/>, color: "#BF34D6" },
-        { label: "Email Service", icon: <Envelope size={20} color="#BF34D6"/>, color: "#BF34D6" },
-      ]
-    },
-    {
-      id: "network",
-      label: "Network & Edge",
-      icon: <Globe size={25} weight="fill" color="#28F0CC"/>,
-      items: [
-        { label: "VPC / Network", icon: <Globe size={20} color="#28F0CC"/>, color: "#28F0CC" },
-        { label: "Subnet", icon: <TreeStructure size={20} color="#28F0CC"/>, color: "#28F0CC" },
-        { label: "CDN", icon: <Cloud size={20} color="#28F0CC"/>, color: "#28F0CC" },
-        { label: "DNS / Domain", icon: <Globe size={20} color="#28F0CC"/>, color: "#28F0CC" },
-        { label: "NAT Gateway", icon: <ArrowsLeftRight size={20} color="#28F0CC"/>, color: "#28F0CC" },
-      ]
-    },
-    {
-      id: "security",
-      label: "Security & Identity",
-      icon: <Shield size={25} weight="fill" color="#46E84C"/>,
-      items: [
-        { label: "Identity Provider", icon: <IdentificationCard size={20} color="#46E84C"/>, color: "#46E84C" },
-        { label: "Secrets Manager", icon: <Key size={20} color="#46E84C"/>, color: "#46E84C" },
-        { label: "WAF", icon: <Wall size={20} color="#46E84C"/>, color: "#46E84C" },
-        { label: "Certificate / SSL", icon: <Certificate size={20} color="#46E84C"/>, color: "#46E84C" },
-      ]
-    },
-    {
-      id: "observability",
-      label: "Observability",
-      icon: <ChartLine size={25} weight="fill" color="#FF802F"/>,
-      items: [
-        { label: "Logging Service", icon: <Scroll size={20} color="#FF802F"/>, color: "#FF802F" },
-        { label: "Metrics / Monitoring", icon: <ChartLine size={20} color="#FF802F"/>, color: "#FF802F" },
-        { label: "Tracing", icon: <Binoculars size={20} color="#FF802F"/>, color: "#FF802F" },
-      ]
-    },
-    {
-      id: "external",
-      label: "External & Users",
-      icon: <User size={25} weight="fill" color="#FF2F5B"/>,
-      items: [
-        { label: "End User / Client", icon: <User size={20} color="#FF2F5B"/>, color: "#FF2F5B" },
-        { label: "3rd Party API", icon: <Plugs size={20} color="#FF2F5B"/>, color: "#FF2F5B" },
-      ]
-    }
-  ];
 
   return (
     <motion.div
@@ -163,7 +53,7 @@ export default function LeftSidebar({ isOpen, toggle, width = 280 }: SidebarProp
           onClick={toggle}
           className="p-1.5 rounded text-black bg-canvas-bg hover:bg-mainColor transition-colors"
         >
-          {isOpen ? <SidebarIcon size={20} /> : <SidebarIcon size={20} />}
+          <SidebarIcon size={20} />
         </button>
       </div>
 
@@ -181,67 +71,79 @@ export default function LeftSidebar({ isOpen, toggle, width = 280 }: SidebarProp
 
       {/* Categories */}
       <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-border-dark scrollbar-track-transparent">
-        {categories.map((category) => (
-          <div key={category.id} className="">
-            <button
-              onClick={() => setActiveCategory(activeCategory === category.id ? null : category.id)}
-              className={`flex w-full items-center justify-between px-4 py-3 hover:bg-canvas-bg transition-colors ${
-                !isOpen && "justify-center px-2"
-              }`}
-              title={!isOpen ? category.label : undefined}
-            >
-              <div className="flex items-center gap-3 text-sm font-medium text-black">
-                <span className={`${activeCategory === category.id ? "text-orange-400" : ""}`}>
-                  {category.icon}
-                </span>
-                {isOpen && <span>{category.label}</span>}
-              </div>
-              {isOpen && (
-                <CaretDown
-                  size={14}
-                  className={`text-muted transition-transform duration-200 ${
-                    activeCategory === category.id ? "rotate-180" : ""
-                  }`}
-                />
-              )}
-            </button>
-            
-            <AnimatePresence>
-              {isOpen && activeCategory === category.id && (
-                <motion.div
-                  initial={{ height: 0, opacity: 0 }}
-                  animate={{ height: "auto", opacity: 1 }}
-                  exit={{ height: 0, opacity: 0 }}
-                  className="overflow-hidden bg-canvas-bg"
-                >
-                  <div className="px-4 pb-3 pt-1 space-y-1">
-                    {category.items.map((item) => (
-                      <div
-                        key={item.label}
-                        className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-border-dark cursor-grab active:cursor-grabbing group transition-colors"
-                        draggable
-                        onDragStart={(e) => {
-                          e.dataTransfer.setData("application/reactflow", item.label);
-                          e.dataTransfer.effectAllowed = "move";
-                        }}
-                      >
-                        <div
-                          className="flex h-9 w-9 items-center justify-center rounded-lg"
-                          style={{ backgroundColor: iconBg(item.color, 0.2) }}
-                        >
-                          {item.icon}
-                        </div>
-                        <span className="text-sm text-black/50 group-hover:text-foreground transition-colors">
-                          {item.label}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
-          </div>
-        ))}
+        {NODE_CATEGories.map((category) => {
+          const CategoryIcon = ICON_MAP[category.iconName];
+          
+          return (
+            <div key={category.id} className="">
+              <button
+                onClick={() => setActiveCategory(activeCategory === category.id ? null : category.id)}
+                className={`flex w-full items-center justify-between px-4 py-3 hover:bg-canvas-bg transition-colors ${
+                  !isOpen && "justify-center px-2"
+                }`}
+                title={!isOpen ? category.label : undefined}
+              >
+                <div className="flex items-center gap-3 text-sm font-medium text-black">
+                  <span className={`${activeCategory === category.id ? "text-orange-400" : ""}`}>
+                    <CategoryIcon size={25} weight="fill" color={category.color} />
+                  </span>
+                  {isOpen && <span>{category.label}</span>}
+                </div>
+                {isOpen && (
+                  <CaretDown
+                    size={14}
+                    className={`text-muted transition-transform duration-200 ${
+                      activeCategory === category.id ? "rotate-180" : ""
+                    }`}
+                  />
+                )}
+              </button>
+              
+              <AnimatePresence>
+                {isOpen && activeCategory === category.id && (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: "auto", opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    className="overflow-hidden bg-canvas-bg"
+                  >
+                    <div className="px-4 pb-3 pt-1 space-y-1">
+                      {category.items.map((item) => {
+                        const ItemIcon = ICON_MAP[item.iconName];
+                        
+                        return (
+                          <div
+                            key={item.label}
+                            className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-border-dark cursor-grab active:cursor-grabbing group transition-colors"
+                            draggable
+                            onDragStart={(e) => {
+                              e.dataTransfer.setData("application/reactflow", item.label);
+                              e.dataTransfer.effectAllowed = "move";
+                            }}
+                          >
+                            <div
+                              className="flex h-9 w-9 items-center justify-center rounded-lg"
+                              style={{ backgroundColor: iconBg(item.color, 0.2) }}
+                            >
+                              {item.imageSrc ? (
+                                <Image src={item.imageSrc} alt={item.label} width={16} height={16} />
+                              ) : (
+                                <ItemIcon size={20} color={item.color} />
+                              )}
+                            </div>
+                            <span className="text-sm text-black/50 group-hover:text-foreground transition-colors">
+                              {item.label}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          );
+        })}
       </div>
     </motion.div>
   );

--- a/components/canvas/PropertiesSidebar.tsx
+++ b/components/canvas/PropertiesSidebar.tsx
@@ -1,0 +1,216 @@
+import { Database, X, Trash, CaretDown, CaretRight } from "@phosphor-icons/react";
+import { useState, useEffect } from "react";
+import { Node } from "reactflow";
+import { motion } from "framer-motion";
+import { ICON_MAP } from "./constants";
+import Image from "next/image";
+
+interface PropertiesSidebarProps {
+  isOpen: boolean;
+  node: Node | null;
+  onClose: () => void;
+  onDelete?: (nodeId: string) => void;
+  onUpdate?: (nodeId: string, data: Record<string, unknown>) => void;
+}
+
+export default function PropertiesSidebar({ isOpen, node, onClose, onDelete, onUpdate }: PropertiesSidebarProps) {
+  // Local state for form fields
+  const [formData, setFormData] = useState<Record<string, unknown>>({});
+
+  // Reset form data when node changes
+  useEffect(() => {
+    if (node) {
+      setFormData({ ...node.data });
+    }
+  }, [node]);
+
+  if (!node) return null;
+
+  const IconComponent = node.data.iconName ? ICON_MAP[node.data.iconName as keyof typeof ICON_MAP] : null;
+  const color = (node.data.color as string) || "#000000";
+
+  // Helper to update field
+  const handleChange = (field: string, value: string | number | boolean) => {
+    const newData = { ...formData, [field]: value };
+    setFormData(newData);
+    if (onUpdate && node) {
+      onUpdate(node.id, newData);
+    }
+  };
+
+  // Render specific fields based on node type
+  const renderFields = () => {
+    // Message Broker / Queue specific logic
+    if (node.data.label === "Message Queue" || node.data.label === "Pub/Sub Topic") {
+      return (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-black/70">Broker Type</label>
+            <div className="relative">
+              <select
+                value={(formData.brokerType as string) || "RabbitMQ"}
+                onChange={(e) => handleChange("brokerType", e.target.value)}
+                className="w-full appearance-none bg-canvas-bg border border-black/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-orange-400"
+              >
+                <option value="RabbitMQ">RabbitMQ</option>
+                <option value="Kafka">Apache Kafka</option>
+                <option value="ActiveMQ">ActiveMQ</option>
+                <option value="SQS">AWS SQS</option>
+                <option value="Redis">Redis Pub/Sub</option>
+              </select>
+              <CaretDown className="absolute right-3 top-1/2 -translate-y-1/2 text-black/40" size={14} />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-black/70">Queue Name</label>
+            <input
+              type="text"
+              value={(formData.queueName as string) || ""}
+              onChange={(e) => handleChange("queueName", e.target.value)}
+              placeholder="e.g. orders-queue"
+              className="w-full bg-canvas-bg border border-black/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-orange-400"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-black/70">Durability</label>
+             <div className="flex gap-4">
+                <label className="flex items-center gap-2 text-sm text-black/70">
+                  <input 
+                    type="radio" 
+                    name="durability"
+                    checked={formData.durability === "durable"} 
+                    onChange={() => handleChange("durability", "durable")}
+                    className="text-orange-500 focus:ring-orange-500"
+                  />
+                  Durable
+                </label>
+                <label className="flex items-center gap-2 text-sm text-black/70">
+                  <input 
+                    type="radio" 
+                    name="durability"
+                    checked={formData.durability === "transient"} 
+                    onChange={() => handleChange("durability", "transient")}
+                    className="text-orange-500 focus:ring-orange-500"
+                  />
+                  Transient
+                </label>
+             </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Default / HTTP Request style (matching image)
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-black/70">Method</label>
+          <div className="relative">
+            <select
+              value={(formData.method as string) || "GET"}
+              onChange={(e) => handleChange("method", e.target.value)}
+              className="w-full appearance-none bg-canvas-bg border border-black/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-orange-400"
+            >
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="DELETE">DELETE</option>
+              <option value="PATCH">PATCH</option>
+            </select>
+            <CaretDown className="absolute right-3 top-1/2 -translate-y-1/2 text-black/40" size={14} />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-black/70">URL</label>
+          <div className="relative">
+            <input
+              type="text"
+              value={(formData.url as string) || ""}
+              onChange={(e) => handleChange("url", e.target.value)}
+              placeholder="https://api.example.com/endpoint"
+              className="w-full bg-canvas-bg border border-black/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-orange-400"
+            />
+            <div className="absolute right-2 top-1/2 -translate-y-1/2 p-1 bg-black/5 rounded cursor-pointer hover:bg-black/10">
+               <Database size={12} className="text-black/50" />
+            </div>
+          </div>
+          <div className="text-xs text-black/40">Use {"{{ trigger.field }}"} for dynamic values</div>
+        </div>
+
+        {/* Collapsible Sections */}
+        {["Headers", "Authentication", "Body", "Query Parameters"].map((section) => (
+          <div key={section} className="border border-black/10 rounded-lg overflow-hidden">
+            <button className="flex items-center justify-between w-full px-3 py-2 bg-canvas-bg/50 hover:bg-canvas-bg transition-colors text-left">
+              <span className="text-sm font-medium text-black/70">{section}</span>
+              <CaretRight size={14} className="text-black/40" />
+            </button>
+          </div>
+        ))}
+
+        <div className="space-y-2 pt-2">
+          <label className="text-sm font-medium text-black/70">Timeout (seconds)</label>
+          <input
+            type="number"
+            value={(formData.timeout as number) || 30}
+            onChange={(e) => handleChange("timeout", Number(e.target.value))}
+            className="w-full bg-canvas-bg border border-black/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-orange-400"
+          />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <motion.div
+      initial={{ x: "100%" }}
+      animate={{ x: isOpen ? 0 : "100%" }}
+      transition={{ duration: 0.3, ease: "easeInOut" }}
+      className="absolute top-0 right-0 h-full w-[380px] bg-white border-l border-border-dark shadow-xl z-50 flex flex-col"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-black/5">
+        <div className="flex items-center gap-3">
+          <div 
+            className="flex items-center justify-center w-10 h-10 rounded-lg bg-opacity-20"
+            style={{ backgroundColor: `${color}33` }} // 20% opacity
+          >
+             {node.data.imageSrc ? (
+               <Image src={node.data.imageSrc} alt={node.data.label} width={20} height={20} className="object-contain" />
+             ) : IconComponent ? (
+               <IconComponent size={24} weight="fill" color={color} />
+             ) : null}
+          </div>
+          <div>
+            <h3 className="font-display font-medium text-black">{node.data.label}</h3>
+            <p className="text-xs text-black/50 font-mono">{node.data.type || "Component"}</p>
+          </div>
+        </div>
+        <button 
+          onClick={onClose}
+          className="p-1.5 hover:bg-black/5 rounded-lg text-black/40 hover:text-black transition-colors"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-4 scrollbar-thin scrollbar-thumb-border-dark scrollbar-track-transparent">
+        {renderFields()}
+      </div>
+
+      {/* Footer */}
+      <div className="p-4 border-t border-black/5">
+        <button 
+          onClick={() => onDelete && onDelete(node.id)}
+          className="flex items-center justify-center gap-2 w-full py-2.5 bg-red-50 hover:bg-red-100 text-red-600 rounded-xl transition-colors font-medium text-sm"
+        >
+          <Trash size={16} />
+          Delete Node
+        </button>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/canvas/RightSidebar.tsx
+++ b/components/canvas/RightSidebar.tsx
@@ -10,7 +10,6 @@ import {
   Plus,
   FileText,
   GithubLogo,
-  File,
   Chat
 } from "@phosphor-icons/react";
 import { motion } from "framer-motion";
@@ -84,11 +83,11 @@ export default function RightSidebar({ isOpen, toggle, width = 380 }: SidebarPro
                 ].map((item) => (
                   <button
                     key={item.title}
-                    className="w-full flex items-center justify-between gap-3 rounded-xl bg-canvas-bg hover:bg-border-dark transition-colors px-4 py-3"
+                    className="w-full flex items-center justify-between gap-3 rounded-xl bg-canvas-bg/70 hover:bg-canvas-bg transition-colors px-4 py-3"
                   >
                     <div className="flex items-center gap-3 min-w-0">
-                      <div className="h-8 w-8 rounded-lg bg-subColor/20 flex items-center justify-center shrink-0">
-                        <Chat size={16} className="text-subColor" weight="fill" />
+                      <div className="h-8 w-8 rounded-lg flex items-center justify-center shrink-0">
+                        <Chat size={20} className="text-subColor" weight="fill" />
                       </div>
                       <span className="text-sm text-black/70 truncate font-display">
                         {item.title}

--- a/components/canvas/TopToolbar.tsx
+++ b/components/canvas/TopToolbar.tsx
@@ -3,13 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { 
-  ArrowUUpLeft, 
-  ArrowUUpRight, 
-  Plus, 
-  Minus, 
   ClockCounterClockwise,
-  ChatText,
-  VideoCamera,
   CaretDown,
   Globe,
   CloudCheckIcon
@@ -51,7 +45,7 @@ export default function TopToolbar() {
         </button>
 
         {/* Share Button */}
-        <div className="flex items-center h-10 bg-mainColor hover:bg-subColor text-[#351300] rounded-full pl-4 pr-2 cursor-pointer transition-colors">
+        <div className="flex items-center h-10 bg-mainColor hover:bg-mainColor/50 text-[#351300] rounded-full pl-4 pr-2 cursor-pointer transition-colors">
           <div className="flex items-center gap-2 pr-3">
             <Globe size={20} />
             <span className="font-semibold text-sm">Share</span>

--- a/components/canvas/constants.tsx
+++ b/components/canvas/constants.tsx
@@ -1,0 +1,178 @@
+import { 
+  Cpu, 
+  Scales, 
+  Shield, 
+  Cube, 
+  Lightning, 
+  Browsers, 
+  Clock, 
+  Database, 
+  Files, 
+  HardDrives, 
+  Warehouse, 
+  MagnifyingGlass, 
+  Queue, 
+  Broadcast, 
+  Waves, 
+  Envelope, 
+  Globe, 
+  TreeStructure, 
+  Cloud, 
+  ArrowsLeftRight, 
+  IdentificationCard, 
+  Key, 
+  Wall, 
+  Certificate, 
+  ChartLine, 
+  Scroll, 
+  Binoculars, 
+  User, 
+  Plugs 
+} from "@phosphor-icons/react";
+
+// Define a mapping of icon names to components
+export const ICON_MAP = {
+  Cpu,
+  Scales,
+  Shield,
+  Cube,
+  Lightning,
+  Browsers,
+  Clock,
+  Database,
+  Files,
+  HardDrives,
+  Warehouse,
+  MagnifyingGlass,
+  Queue,
+  Broadcast,
+  Waves,
+  Envelope,
+  Globe,
+  TreeStructure,
+  Cloud,
+  ArrowsLeftRight,
+  IdentificationCard,
+  Key,
+  Wall,
+  Certificate,
+  ChartLine,
+  Scroll,
+  Binoculars,
+  User,
+  Plugs
+};
+
+// Define the structure for a node item
+export interface NodeItem {
+  label: string;
+  iconName: keyof typeof ICON_MAP;
+  color: string;
+  imageSrc?: string; // For items that use images instead of Phosphor icons (e.g. Postgres)
+}
+
+// Define the structure for a category
+export interface NodeCategory {
+  id: string;
+  label: string;
+  iconName: keyof typeof ICON_MAP;
+  color: string;
+  items: NodeItem[];
+}
+
+export const NODE_CATEGories: NodeCategory[] = [
+  {
+    id: "compute",
+    label: "Compute & Logic",
+    iconName: "Cpu",
+    color: "#FF2F9F",
+    items: [
+      { label: "Load Balancer", iconName: "Scales", color: "#FF2F9F" },
+      { label: "API Gateway", iconName: "Shield", color: "#FF2F9F" },
+      { label: "Microservice", iconName: "Cube", color: "#FF2F9F" },
+      { label: "Serverless Function", iconName: "Lightning", color: "#FF2F9F" },
+      { label: "Monolith App", iconName: "Browsers", color: "#FF2F9F" },
+      { label: "Scheduler/Worker", iconName: "Clock", color: "#FF2F9F" },
+    ]
+  },
+  {
+    id: "data",
+    label: "Data & Storage",
+    iconName: "Database",
+    color: "#2FC1FF",
+    items: [
+      { label: "Relational DB", iconName: "Database", color: "#2FC1FF", imageSrc: "/postgresql.png" },
+      { label: "NoSQL DB", iconName: "Files", color: "#2FC1FF" },
+      { label: "Cache", iconName: "Database", color: "#2FC1FF", imageSrc: "/redis.png" },
+      { label: "Object Storage", iconName: "HardDrives", color: "#2FC1FF" },
+      { label: "Data Warehouse", iconName: "Warehouse", color: "#2FC1FF" },
+      { label: "Search Engine", iconName: "MagnifyingGlass", color: "#2FC1FF" },
+    ]
+  },
+  {
+    id: "messaging",
+    label: "Messaging & Streaming",
+    iconName: "Broadcast",
+    color: "#BF34D6",
+    items: [
+      { label: "Message Queue", iconName: "Queue", color: "#BF34D6" },
+      { label: "Pub/Sub Topic", iconName: "Broadcast", color: "#BF34D6" },
+      { label: "Event Stream", iconName: "Waves", color: "#BF34D6" },
+      { label: "Email Service", iconName: "Envelope", color: "#BF34D6" },
+    ]
+  },
+  {
+    id: "network",
+    label: "Network & Edge",
+    iconName: "Globe",
+    color: "#28F0CC",
+    items: [
+      { label: "VPC / Network", iconName: "Globe", color: "#28F0CC" },
+      { label: "Subnet", iconName: "TreeStructure", color: "#28F0CC" },
+      { label: "CDN", iconName: "Cloud", color: "#28F0CC" },
+      { label: "DNS / Domain", iconName: "Globe", color: "#28F0CC" },
+      { label: "NAT Gateway", iconName: "ArrowsLeftRight", color: "#28F0CC" },
+    ]
+  },
+  {
+    id: "security",
+    label: "Security & Identity",
+    iconName: "Shield",
+    color: "#46E84C",
+    items: [
+      { label: "Identity Provider", iconName: "IdentificationCard", color: "#46E84C" },
+      { label: "Secrets Manager", iconName: "Key", color: "#46E84C" },
+      { label: "WAF", iconName: "Wall", color: "#46E84C" },
+      { label: "Certificate / SSL", iconName: "Certificate", color: "#46E84C" },
+    ]
+  },
+  {
+    id: "observability",
+    label: "Observability",
+    iconName: "ChartLine",
+    color: "#FF802F",
+    items: [
+      { label: "Logging Service", iconName: "Scroll", color: "#FF802F" },
+      { label: "Metrics / Monitoring", iconName: "ChartLine", color: "#FF802F" },
+      { label: "Tracing", iconName: "Binoculars", color: "#FF802F" },
+    ]
+  },
+  {
+    id: "external",
+    label: "External & Users",
+    iconName: "User",
+    color: "#FF2F5B",
+    items: [
+      { label: "End User / Client", iconName: "User", color: "#FF2F5B" },
+      { label: "3rd Party API", iconName: "Plugs", color: "#FF2F5B" },
+    ]
+  }
+];
+
+export const getNodeConfig = (label: string): NodeItem | undefined => {
+  for (const category of NODE_CATEGories) {
+    const item = category.items.find((i) => i.label === label);
+    if (item) return item;
+  }
+  return undefined;
+};

--- a/components/canvas/nodes/UniversalNode.tsx
+++ b/components/canvas/nodes/UniversalNode.tsx
@@ -1,0 +1,89 @@
+import { memo } from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+import Image from 'next/image';
+import { ICON_MAP } from '../constants';
+
+const hexToRgba = (hex: string, alpha: number) => {
+  if (!hex) return `rgba(0, 0, 0, ${alpha})`;
+  const normalized = hex.replace("#", "");
+  const full = normalized.length === 3 ? normalized.split("").map((c) => c + c).join("") : normalized;
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+const UniversalNode = ({ data, selected }: NodeProps) => {
+  const IconComponent = data.iconName ? ICON_MAP[data.iconName as keyof typeof ICON_MAP] : null;
+  const color = data.color || '#000000';
+  const bgColor = hexToRgba(color, 0.1); // 10% opacity for background
+  const borderColor = hexToRgba(color, 0.5); // 50% opacity for border
+
+  return (
+    <div className="relative group">
+      {/* Node Container */}
+      <div
+        className={`
+          flex flex-col items-center justify-center
+          w-20 h-20 rounded-2xl
+          border-2 transition-all duration-200
+          ${selected ? 'ring-2 ring-offset-2 ring-offset-white' : ''}
+        `}
+        style={{
+          backgroundColor: bgColor,
+          borderColor: selected ? color : borderColor,
+          // Box shadow for depth
+          boxShadow: selected ? `0 4px 12px ${hexToRgba(color, 0.2)}` : 'none',
+        }}
+      >
+        {/* Icon or Image */}
+        <div className="flex items-center justify-center text-foreground">
+          {data.imageSrc ? (
+            <div className="relative w-8 h-8">
+              <Image 
+                src={data.imageSrc} 
+                alt={data.label} 
+                fill 
+                className="object-contain"
+              />
+            </div>
+          ) : IconComponent ? (
+            <IconComponent 
+              size={32} 
+              weight="fill" 
+              color={color}
+            />
+          ) : null}
+        </div>
+
+        {/* Status Indicator (Optional - mimicking the red warning in reference image) */}
+        {data.status === 'error' && (
+          <div className="absolute -bottom-1 -right-1 bg-white rounded-full p-0.5 shadow-sm">
+             <div className="w-4 h-4 rounded-full bg-red-500 flex items-center justify-center text-[10px] text-white font-bold">!</div>
+          </div>
+        )}
+      </div>
+
+      {/* Label (Outside the box) */}
+      <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 whitespace-nowrap">
+        <span className="text-xs font-medium text-black/70 font-display">
+          {data.label}
+        </span>
+      </div>
+
+      {/* Handles */}
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!w-2 !h-2 !bg-white !border-2 !border-black/20"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!w-2 !h-2 !bg-white !border-2 !border-black/20"
+      />
+    </div>
+  );
+};
+
+export default memo(UniversalNode);


### PR DESCRIPTION
- Add UniversalNode component with opacity-based background styling
- Create PropertiesSidebar with dynamic form fields (Message Broker, HTTP Request)
- Centralize node configuration in constants.tsx
- Update CanvasLayout to handle node selection and sidebar toggling
- Refactor CanvasArea to use UniversalNode for all node types