### PR TITLE
feat(canvas): implement new tool sidebar and insert menu navigation

### DIFF
--- a/components/canvas/CanvasLayout.tsx
+++ b/components/canvas/CanvasLayout.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import { Node } from "reactflow";
 import LeftSidebar from "./LeftSidebar";
+import ToolSidebar from "./ToolSidebar";
+import InsertMenu from "./InsertMenu";
 import RightSidebar from "./RightSidebar";
 import PropertiesSidebar from "./PropertiesSidebar";
 import TopToolbar from "./TopToolbar";
@@ -10,23 +12,36 @@ import CanvasArea from "./CanvasArea";
 import { CaretLeft } from "@phosphor-icons/react";
 
 export default function CanvasLayout() {
-  const [leftSidebarOpen, setLeftSidebarOpen] = useState(true);
+  const [isInsertMenuOpen, setIsInsertMenuOpen] = useState(false);
+  const [isComponentLibraryOpen, setIsComponentLibraryOpen] = useState(false);
+  const [activeTool, setActiveTool] = useState("select");
   const [rightSidebarOpen, setRightSidebarOpen] = useState(true);
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [leftWidth] = useState(280);
   const [rightWidth] = useState(380);
 
-  // Persist state
+  // Toggle Insert Menu
+  const toggleInsertMenu = () => {
+    if (isInsertMenuOpen) {
+      setIsInsertMenuOpen(false);
+    } else {
+      setIsInsertMenuOpen(true);
+      setIsComponentLibraryOpen(false); // Close component library when opening insert menu
+    }
+  };
+
+  // Handle diagram selection from Insert Menu
+  const handleDiagramSelect = (type: string) => {
+    // For now, any selection opens the component library
+    setIsInsertMenuOpen(false);
+    setIsComponentLibraryOpen(true);
+  };
+
+  // Persist state (Right Sidebar only for now)
   useEffect(() => {
-    const savedLeft = localStorage.getItem("canvas-left-sidebar");
     const savedRight = localStorage.getItem("canvas-right-sidebar");
-    if (savedLeft) setLeftSidebarOpen(savedLeft === "true");
     if (savedRight) setRightSidebarOpen(savedRight === "true");
   }, []);
-
-  useEffect(() => {
-    localStorage.setItem("canvas-left-sidebar", leftSidebarOpen.toString());
-  }, [leftSidebarOpen]);
 
   useEffect(() => {
     localStorage.setItem("canvas-right-sidebar", rightSidebarOpen.toString());
@@ -36,11 +51,34 @@ export default function CanvasLayout() {
     <div className="flex h-screen w-screen flex-col overflow-hidden bg-[var(--color-background)] text-foreground">
       <TopToolbar />
       <div className="flex flex-1 overflow-hidden relative">
-        <LeftSidebar 
-          isOpen={leftSidebarOpen} 
-          toggle={() => setLeftSidebarOpen(!leftSidebarOpen)} 
-          width={leftWidth}
+        {/* Tool Sidebar (Always visible) */}
+        <ToolSidebar 
+          isOpen={isInsertMenuOpen || isComponentLibraryOpen} 
+          toggle={() => {
+            if (isInsertMenuOpen || isComponentLibraryOpen) {
+              setIsInsertMenuOpen(false);
+              setIsComponentLibraryOpen(false);
+            } else {
+              setIsInsertMenuOpen(true);
+            }
+          }}
+          activeTool={activeTool}
+          setActiveTool={setActiveTool}
         />
+
+        {/* Insert Menu (Overlay or Push) */}
+        <InsertMenu 
+          isOpen={isInsertMenuOpen} 
+          onSelectDiagram={handleDiagramSelect}
+          width={320}
+        />
+
+        {/* Component Library (Left Sidebar) */}
+        {/* <LeftSidebar 
+          isOpen={isComponentLibraryOpen} 
+          toggle={() => setIsComponentLibraryOpen(!isComponentLibraryOpen)} 
+          width={leftWidth}
+        /> */}
         
         <CanvasArea onNodeSelect={setSelectedNode} />
         

--- a/components/canvas/InsertMenu.tsx
+++ b/components/canvas/InsertMenu.tsx
@@ -1,0 +1,117 @@
+import { MagnifyingGlass, Sparkle, TreeStructure, Cloud, ChartBar, Database, FileCode } from "@phosphor-icons/react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface InsertMenuProps {
+  isOpen: boolean;
+  onSelectDiagram: (type: string) => void;
+  width?: number;
+}
+
+export default function InsertMenu({ isOpen, onSelectDiagram, width = 320 }: InsertMenuProps) {
+  const menuItems = [
+    {
+      id: "ai",
+      label: "AI diagram",
+      description: "Generate diagram with natural language",
+      icon: Sparkle,
+      color: "text-white"
+    },
+    {
+      id: "flowchart",
+      label: "Flow Chart",
+      description: "Visualize process and logic flows",
+      icon: TreeStructure,
+      color: "text-white"
+    },
+    {
+      id: "cloud",
+      label: "Cloud Architecture",
+      description: "Visualize your infrastructure",
+      icon: Cloud,
+      color: "text-white"
+    },
+    {
+      id: "bpmn",
+      label: "BPMN",
+      description: "Visualize business processes with swimlanes",
+      icon: ChartBar,
+      color: "text-white"
+    },
+    {
+      id: "erd",
+      label: "Entity Relationship",
+      description: "Visualize data models",
+      icon: Database,
+      color: "text-white"
+    },
+    {
+      id: "sequence",
+      label: "Sequence",
+      description: "Visualize system flow and interactions",
+      icon: TreeStructure,
+      color: "text-white"
+    },
+    {
+      id: "image",
+      label: "Image-to-diagram",
+      description: "Import image file",
+      icon: FileCode,
+      color: "text-white"
+    }
+  ];
+
+  return (
+    <motion.div
+      initial={{ width: 0, opacity: 0 }}
+      animate={{ 
+        width: isOpen ? width : 0, 
+        opacity: isOpen ? 1 : 0 
+      }}
+      transition={{ duration: 0.3, ease: "easeInOut" }}
+      className="flex h-full flex-col bg-[#1A1A1A] overflow-hidden z-40 border-r border-white/10"
+    >
+      <div className="flex flex-col h-full w-[320px] shrink-0">
+        {/* Header / Search */}
+        <div className="p-4 pt-6">
+          <div className="relative">
+            <MagnifyingGlass size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-white/50" />
+            <input
+              type="text"
+              placeholder="Insert item"
+              className="w-full bg-white/5 rounded-lg py-2.5 pl-10 pr-3 text-sm text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/20 transition-all"
+            />
+          </div>
+          
+          <div className="mt-6 mb-2 flex items-center gap-2 text-xs font-medium text-white/40 px-1">
+            <span>All Categories</span>
+            <span>/</span>
+            <span className="text-white">Diagram as Code</span>
+          </div>
+        </div>
+
+        {/* Menu Items */}
+        <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-2 scrollbar-thin scrollbar-thumb-white/10 scrollbar-track-transparent">
+          {menuItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => onSelectDiagram(item.id)}
+              className="flex items-start gap-4 w-full p-4 rounded-xl bg-white/5 hover:bg-white/10 border border-white/5 hover:border-white/10 transition-all group text-left"
+            >
+              <div className="mt-0.5">
+                <item.icon size={24} weight="fill" className={item.color} />
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <span className="text-sm font-semibold text-white group-hover:text-white transition-colors">
+                  {item.label}
+                </span>
+                <span className="text-xs text-white/50 font-medium">
+                  {item.description}
+                </span>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/canvas/ToolSidebar.tsx
+++ b/components/canvas/ToolSidebar.tsx
@@ -1,0 +1,80 @@
+import { 
+  Cursor, 
+  HandGrabbing, 
+  Square, 
+  Circle, 
+  ArrowUpRight, 
+  Pencil, 
+  TextT, 
+  Plus, 
+  X,
+  Sparkle
+} from "@phosphor-icons/react";
+
+interface ToolSidebarProps {
+  isOpen: boolean;
+  toggle: () => void;
+  activeTool: string;
+  setActiveTool: (tool: string) => void;
+}
+
+export default function ToolSidebar({ isOpen, toggle, activeTool, setActiveTool }: ToolSidebarProps) {
+  const tools = [
+    { id: "select", icon: Cursor, label: "Select" },
+    { id: "hand", icon: HandGrabbing, label: "Pan" },
+    { id: "rectangle", icon: Square, label: "Rectangle" },
+    { id: "circle", icon: Circle, label: "Circle" },
+    { id: "line", icon: ArrowUpRight, label: "Line" },
+    { id: "draw", icon: Pencil, label: "Draw" },
+    { id: "text", icon: TextT, label: "Text" },
+    { id: "ai", icon: Sparkle, label: "AI Generate" },
+  ];
+
+  return (
+    <div className="flex h-full w-[60px] flex-col items-center bg-foreground py-4 z-50 border-r border-border-dark/50 shadow-sm">
+      {/* Toggle Button */}
+      <button
+        onClick={toggle}
+        className={`
+          flex h-10 w-10 items-center justify-center rounded-xl 
+          transition-all duration-300 mb-6
+          ${isOpen 
+            ? "bg-black text-white hover:bg-black/80" 
+            : "bg-canvas-bg text-black hover:bg-mainColor hover:text-white"
+          }
+        `}
+      >
+        {isOpen ? <X size={20} weight="bold" /> : <Plus size={20} weight="bold" />}
+      </button>
+
+      {/* Tools */}
+      <div className="flex flex-col gap-3 w-full px-2">
+        {tools.map((tool) => (
+          <button
+            key={tool.id}
+            onClick={() => setActiveTool(tool.id)}
+            className={`
+              group relative flex h-10 w-full items-center justify-center rounded-lg 
+              transition-colors duration-200
+              ${activeTool === tool.id 
+                ? "bg-orange-50 text-orange-500" 
+                : "text-muted hover:bg-canvas-bg hover:text-black"
+              }
+            `}
+            title={tool.label}
+          >
+            <tool.icon 
+              size={20} 
+              weight={activeTool === tool.id ? "fill" : "regular"} 
+            />
+            
+            {/* Tooltip */}
+            <div className="absolute left-full ml-2 hidden rounded bg-black px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:block group-hover:opacity-100 whitespace-nowrap z-50 pointer-events-none">
+              {tool.label}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add ToolSidebar with drawing tools and toggle button
- Add InsertMenu with diagram category selection (AI, Cloud, Flowchart)
- Update CanvasLayout to orchestrate sidebar states (Tool -> Insert -> Component Library)
- Integrate new navigation flow where selecting a diagram type reveals the component library